### PR TITLE
travis - fix OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,12 +30,27 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" = osx ]]; then
       rvm install ruby-2.3.3;
       rvm --default use 2.3.3;
-      brew install openssl;
+      ruby --version;
+      brew update;
+      brew upgrade openssl;
+      brew upgrade python;
+      export PATH="/usr/local/opt/python/libexec/bin:$PATH";
+      export PYTHONPATH=`brew --prefix`/lib/python2.7/site-packages:$PYTHONPATH;
       export CPPFLAGS="-I/usr/local/opt/openssl/include";
       export LDFLAGS="-L/usr/local/opt/openssl/lib";
+      python --version;
+      python -c "import ssl; print ssl.OPENSSL_VERSION";
+      pip install --upgrade pip setuptools;
     fi
   # Install conan
-  - if [ "$TRAVIS_OS_NAME" = osx ]; then pip install "conan==0.28.1"; else pip install --user "conan==0.28.1"; fi
+  - if [ "$TRAVIS_OS_NAME" = osx ]; then
+      pip install "conan==0.28.1";
+      pip uninstall pyopenssl;
+      pip uninstall cryptography;
+      pip install "pyopenssl>=16.0.0, <17.0.0";
+    else
+      pip install --user "conan==0.28.1";
+    fi
   - conan remote add joystream https://api.bintray.com/conan/joystream/joystream True
 install:
 


### PR DESCRIPTION
When pip installs conan on osx seems to install latest version of dependencies (pyopenssl) that expect openssl 1.1.x. The version we are using is 1.0.x (and needed to build some node dependencies) This was causing a runtime error when downloading conan recipes over https.

This hack reverts the dependency to a version that binds to the version of openssl ssl 1.0.x we need.
