### PR TITLE
support saving and loading torrents without metadata

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -543,10 +543,10 @@ class Application extends EventEmitter {
     }
 
     // Add torrents paramaters should only have one of ti, url or infoHash
-    if (settings.metadata) {
-      params.ti = settings.metadata
-    } else if (settings.url) {
+    if (settings.url) {
       params.url = settings.url
+    else if (settings.metadata) {
+      params.ti = settings.metadata
     } else {
       params.infoHash = infoHash
     }


### PR DESCRIPTION
- [x] If a torrent is added with an infohash or magnet link, libtorrent will need to fetch the metadata first.
We now allow the torrent to be saved to the database even if the torrent data is not yet available.
Note: additional information in a magnet link like trackers etc will be saved in the fast resume data.

- [x] When libtorrent processes the add torrent parameters it first looks for a ~TorrentInfo, then and infoHash and finally a url~ url, then a TorrentInfo and finally just the infoHash. So we will make sure to only add one of them to reflect this behavior.