### PR TITLE
pass `null` instead of `undefined` as argument

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -235,7 +235,7 @@ class Application extends EventEmitter {
      */
 
     // Hold on to price feed
-    this.priceFeed = new PriceFeed(undefined, exchangeRateFetcher)
+    this.priceFeed = new PriceFeed(null, exchangeRateFetcher)
 
     this.priceFeed.on('error', this._onPriceFeedError)
 
@@ -582,7 +582,7 @@ class Application extends EventEmitter {
         let torrent = this._onTorrentAddedToSession(settings, newJoystreamNodeTorrent)
 
         // and finally tell user
-        onAdded(undefined, torrent)
+        onAdded(null, torrent)
 
       }
 
@@ -721,7 +721,7 @@ class Application extends EventEmitter {
     }
 
     // Tell user about success
-    onRemoved(undefined, true)
+    onRemoved(null, true)
 
   }
 
@@ -739,7 +739,7 @@ class Application extends EventEmitter {
       this._setState(Application.STATE.STARTED)
 
       // Make callback to user
-      onStarted(undefined, true)
+      onStarted(null, true)
     }
 
     // tell the world
@@ -763,7 +763,7 @@ class Application extends EventEmitter {
       this._setState(Application.STATE.STOPPED)
 
       // Make user callback
-      onStopped(undefined, true)
+      onStopped(null, true)
     }
 
     // tell the world


### PR DESCRIPTION
Is generally better practice to use null when explicitly passing an "empty" value