### PR TITLE
fix import/require DeepInitialState statements

### DIFF
--- a/src/core/Torrent/Statemachine/Torrent.js
+++ b/src/core/Torrent/Statemachine/Torrent.js
@@ -5,7 +5,7 @@ var BaseMachine = require('../../BaseMachine')
 var Loading = require('./Loading/Loading')
 var Active = require('./Active')
 var Common = require('./Common')
-var DeepInitialState = require('./DeepInitialState')
+var DeepInitialState = require('./DeepInitialState').default
 
 const assert = require('assert')
 
@@ -14,7 +14,7 @@ var Torrent = new BaseMachine({
     initialState: "Loading",
 
     states: {
-        
+
         Loading : {
 
             _child : Loading,

--- a/src/core/Torrent/Statemachine/index.js
+++ b/src/core/Torrent/Statemachine/index.js
@@ -3,7 +3,7 @@
  */
 
 var Torrent = require('./Torrent')
-var DeepInitialState = require('./DeepInitialState')
+var DeepInitialState = require('./DeepInitialState').default
 
 module.exports = Torrent
 module.exports.DeepInitialState = DeepInitialState


### PR DESCRIPTION
We must remember to get the default value when `require`ing an ES6 module