### PR TITLE
New PeerStore

### DIFF
--- a/src/core-stores/Peer/PeerStore.js
+++ b/src/core-stores/Peer/PeerStore.js
@@ -1,0 +1,73 @@
+/**
+ * Created by bedeho on 10/02/2018.
+ */
+
+import { observable, action } from 'mobx'
+import { BEPSupportStatus } from 'joystream-node'
+
+class PeerStore {
+
+  /**
+   * {String} Peer identifier
+   */
+  peerId
+
+  /**
+   * {String} State of peer
+   */
+  state
+
+  /**
+   * {joystream-node.PeerPluginStatus} Status of plugin on peer
+   */
+  @observable peerPluginStatus
+
+  /**
+   * Constructor
+   * @param peerId {String} - Peer identifier
+   * @param state {String} - State of peer
+   * @param peerPluginStatus {joystream-node.PeerPluginStatus} - Status of plugin on peer
+   */
+  constructor(peerId, state, peerPluginStatus) {
+    this.peerId = peerId
+    this.setState(state)
+    this.setPeerPluginStatus(peerPluginStatus)
+  }
+
+  @action.bound
+  setState(state) {
+    this.state = state
+  }
+
+  @action.bound
+  setPeerPluginStatus(peerPluginStatus) {
+    this.peerPluginStatus = peerPluginStatus
+  }
+
+  @computed get
+  peerSupportsProtocol() {
+    return this.peerPluginStatus.peerBitSwaprBEPSupportStatus === BEPSupportStatus.supported
+  }
+
+  @computed get
+  peerIsBuyer() {
+    return hasConnection(this.peerPluginStatus) && this.peerPluginStatus.connection.announcedModeAndTermsFromPeer.buyer
+  }
+
+  @computed get
+  peerIsSeller() {
+    return hasConnection(this.peerPluginStatus) && this.peerPluginStatus.connection.announcedModeAndTermsFromPeer.seller
+  }
+
+  @computed get
+  peerIsObserver() {
+    return hasConnection(this.peerPluginStatus) && this.peerPluginStatus.connection.announcedModeAndTermsFromPeer.observer
+  }
+
+}
+
+function hasConnection(status) {
+  return status.peerBitSwaprBEPSupportStatus === BEPSupportStatus.supported && status.connection
+}
+
+

--- a/src/core-stores/Peer/PeerStore.js
+++ b/src/core-stores/Peer/PeerStore.js
@@ -67,7 +67,7 @@ class PeerStore {
 }
 
 function hasConnection(status) {
-  return status.peerBitSwaprBEPSupportStatus === BEPSupportStatus.supported && status.connection
+  return (status.peerBitSwaprBEPSupportStatus === BEPSupportStatus.supported) && status.connection
 }
 
 

--- a/src/core-stores/Peer/index.js
+++ b/src/core-stores/Peer/index.js
@@ -1,0 +1,7 @@
+/**
+ * Created by bedeho on 10/02/2018.
+ */
+
+import PeerStore from './PeerStore'
+
+export default PeerStore

--- a/src/core-stores/Torrent/TorrentStore.js
+++ b/src/core-stores/Torrent/TorrentStore.js
@@ -293,8 +293,9 @@ class TorrentStore {
 
       this.peerStores.forEach((store, pid) => {
 
-        if(store.peerIsBuyer)
+        if(store.peerIsBuyer) {
           n++
+        }
 
       })
 
@@ -307,8 +308,10 @@ class TorrentStore {
 
       this.peerStores.forEach((store, pid) => {
 
-        if(store.peerIsSeller)
+        if(store.peerIsSeller) {
           n++
+        }
+        
       })
 
       return n
@@ -320,8 +323,10 @@ class TorrentStore {
 
       this.peerStores.forEach((store, pid) => {
 
-        if(store.peerIsObserver)
+        if(store.peerIsObserver) {
           n++
+        }
+        
       })
 
       return n
@@ -333,8 +338,10 @@ class TorrentStore {
 
       this.peerStores.forEach((store, pid) => {
 
-        if(store.peerSupportsProtocol)
+        if(store.peerSupportsProtocol) {
           n++
+        }
+        
       })
 
       return n

--- a/src/core-stores/Torrent/TorrentStore.js
+++ b/src/core-stores/Torrent/TorrentStore.js
@@ -1,5 +1,5 @@
 import { observable, action, computed } from 'mobx'
-import { BEPSupportStatus } from 'joystream-node'
+
 import ViabilityOfPaidDownloadInSwarm from '../../core/Torrent/ViabilityOfPaidDownloadingSwarm'
 import ViabilityOfPaidDownloadingTorrent from '../../core/Torrent/ViabilityOfPaidDownloadingTorrent'
 
@@ -59,13 +59,17 @@ class TorrentStore {
     @observable uploadedTotal
     @observable name
 
-    @observable numberOfBuyers
-    @observable numberOfSellers
-    @observable numberOfObservers
-    @observable numberOfNormalPeers
-    @observable numberOfSeeders
-
     @observable viabilityOfPaidDownloadInSwarm
+
+    /**
+     * {Map.<String,PeerStore>} Maps peer id to peer store for corresponding peer
+     */
+    @observable peerStores
+
+    /**
+     * {Number} Number of peers classified as seeders (by libtorrent)
+     */
+    @observable numberOfSeeders
 
     constructor (infoHash,
                  savePath,
@@ -77,15 +81,11 @@ class TorrentStore {
                  uploadSpeed,
                  uploadedTotal,
                  name,
-                 numberOfBuyers,
-                 numberOfSellers,
-                 numberOfObservers,
-                 numberOfNormalPeers,
-                 numberOfSeeders,
                  sellerPrice,
                  sellerRevenue,
                  buyerPrice,
                  buyerSpent,
+                 numberOfSeeders,
                  starter,
                  stopper,
                  folderOpener,
@@ -116,6 +116,8 @@ class TorrentStore {
         this.buyerPrice = buyerPrice ? buyerPrice : 0
         this.buyerSpent = buyerSpent ? buyerSpent : new Map()
      */
+
+        this.peerStores = new Map()
 
         this._starter = starter
         this._stopper = stopper
@@ -171,33 +173,13 @@ class TorrentStore {
     }
 
     @action.bound
+    setNumberOfSeeders(numberOfSeeders) {
+      this.numberOfSeeders = numberOfSeeders
+    }
+
+    @action.bound
     setProgress (progress) {
         this.progress = progress
-    }
-
-    @action.bound
-    setNumberOfBuyers (numberOfBuyers) {
-        this.numberOfBuyers = numberOfBuyers
-    }
-
-    @action.bound
-    setNumberOfSellers (numberOfSellers) {
-        this.numberOfSellers = numberOfSellers
-    }
-
-    @action.bound
-    setNumberOfObservers (numberOfObservers) {
-        this.numberOfObservers = numberOfObservers
-    }
-
-    @action.bound
-    setNumberOfNormalPeers (numberOfNormalPeers) {
-        this.numberOfNormalPeers = numberOfNormalPeers
-    }
-
-    @action.bound
-    setNumberOfSeeders(numberOfSeeders) {
-        this.numberOfSeeders = numberOfSeeders
     }
 
     @action.bound
@@ -303,6 +285,59 @@ class TorrentStore {
             sum += value
         })
         return sum
+    }
+
+    @computed get numberOfBuyers() {
+
+      let n = 0
+
+      this.peerStores.forEach((store, pid) => {
+
+        if(store.peerIsBuyer)
+          n++
+
+      })
+
+      return n
+    }
+
+    @computed get numberOfSellers() {
+
+      let n = 0
+
+      this.peerStores.forEach((store, pid) => {
+
+        if(store.peerIsSeller)
+          n++
+      })
+
+      return n
+    }
+
+    @computed get numberOfObservers() {
+
+      let n = 0
+
+      this.peerStores.forEach((store, pid) => {
+
+        if(store.peerIsObserver)
+          n++
+      })
+
+      return n
+    }
+
+    @computed get numberOfNormalPeers() {
+
+      let n = 0
+
+      this.peerStores.forEach((store, pid) => {
+
+        if(store.peerSupportsProtocol)
+          n++
+      })
+
+      return n
     }
 
     start() {

--- a/src/core-stores/index.js
+++ b/src/core-stores/index.js
@@ -1,12 +1,14 @@
 
 import ApplicationStore from './Application'
 import TorrentStore from './Torrent'
+import PeerStore from './Peer'
 import WalletStore from './Wallet'
 import PriceFeedStore from './PriceFeed'
 
 export {
   ApplicationStore,
   TorrentStore,
+  PeerStore,
   WalletStore,
   PriceFeedStore
 }

--- a/src/core/Peer/Peer.js
+++ b/src/core/Peer/Peer.js
@@ -4,6 +4,11 @@
 
 var PeerStatemachine = require('./Statemachine')
 
+import EventEmitter from 'events'
+import util from 'util'
+
+util.inherits(Peer, EventEmitter)
+
 /// Peer class
 
 /**
@@ -20,7 +25,13 @@ function Peer(pid, torrent, status, privateKeyGenerator, publicKeyHashGenerator)
 }
 
 Peer.prototype.newStatus = function(status) {
-    this._client._submitInput('newStatus', status)
+     this._client._submitInput('newStatus', status)
+
+  /**
+   * HACK, adding these three functions until this PR can be done.
+   * https://github.com/JoyStream/joystream-desktop/issues/684
+   */
+  this.emit('peerPluginStatus', status)
 }
 
 Peer.prototype.compositeState = function() {
@@ -33,6 +44,23 @@ Peer.prototype.anchorAnnounced = function (alert) {
 
 Peer.prototype.uploadStarted = function (alert) {
   this._client._submitInput('uploadStarted', alert)
+}
+
+/**
+ * HACK, adding these three functions until this PR can be done.
+ * https://github.com/JoyStream/joystream-desktop/issues/684
+ */
+
+Peer.prototype.pid = function () {
+  return this._client.pid
+}
+
+Peer.prototype.state = function () {
+  return this.compositeState()
+}
+
+Peer.prototype.peerPluginStatus = function () {
+  return this._client.status
 }
 
 /// PeerStatemachineClient class

--- a/src/core/Torrent/Statemachine/Common.js
+++ b/src/core/Torrent/Statemachine/Common.js
@@ -37,7 +37,7 @@ function processPeerPluginStatuses(client, statuses) {
 
             client.peers.set(s.pid, newPeer)
 
-            client.emit('peerPluginPresent', newPeer)
+            client.emit('peerAdded', newPeer)
         }
 
         // Mark as present
@@ -53,7 +53,7 @@ function processPeerPluginStatuses(client, statuses) {
 
           client.peers.delete(pid)
 
-          client.emit('peerPluginGone', pid)
+          client.emit('peerRemoved', pid)
         }
 
     }

--- a/src/core/Torrent/Torrent.js
+++ b/src/core/Torrent/Torrent.js
@@ -27,8 +27,8 @@ import {deepInitialStateFromActiveState} from './Statemachine/DeepInitialState'
  * snapshots of plugin state at regular intervals.
  * The arrival & disappearance of peer plugins may be missed
  * in theory:
- * emits peerPluginPresent({Peer}) - when peer plugin is first seens as present
- * emits peerPluginGone({PID}) - when peer plugin is first seens as gone
+ * emits peerAdded({Peer}) - when peer plugin is first seens as present
+ * emits peerRemoved({PID}) - when peer plugin is first seens as gone
  */
 class Torrent extends EventEmitter {
 

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -6,6 +6,7 @@ import {shell} from 'electron'
 import {
   ApplicationStore,
   TorrentStore,
+  PeerStore,
   WalletStore,
   PriceFeedStore} from '../core-stores'
 
@@ -424,17 +425,43 @@ class UIStore {
 
     })
 
-    torrent.on('peer-plugin-status', (peerPluginStatuses) => {
+    /**
+     * When a peer is added,
+     * we create a peer store which watches the peer and
+     * synches its own observables. Also we add
+     * store to torrent store
+     */
+    torrent.on('peerAdded', action((peer) => {
 
-      let peerCounts = peerCountsFromPluginStatuses(peerPluginStatuses)
+      let pid = peer.pid()
 
-      // Update torrent store
-      torrentStore.setNumberOfBuyers(peerCounts.buyers)
-      torrentStore.setNumberOfSellers(peerCounts.sellers)
-      torrentStore.setNumberOfObservers(peerCounts.observers)
-      torrentStore.setNumberOfNormalPeers(peerCounts.normals)
+      let peerStore = new PeerStore(
+        pid,
+        peer.state(),
+        peer.peerPluginStatus()
+      )
 
-    })
+      peer.on('peerPluginStatus', action((peerPluginStatus) => {
+        peerStore.setPeerPluginStatus(peerPluginStatus)
+      }))
+
+      assert(!torrentStore.peerStores.has(pid))
+
+      torrentStore.peerStores.set(pid, peerStore)
+
+    }))
+
+    /**
+     * When peer is removed, drop peer store from the
+     * torrent store
+     */
+    torrent.on('peerRemoved', action((peerId) => {
+
+      assert(torrentStore.has(peerId))
+
+      torrentStore.peerStores.delete(peerId)
+
+    }))
 
     torrent.on('viabilityOfPaidDownloadInSwarm', action((viabilityOfPaidDownloadInSwarm) => {
 
@@ -748,6 +775,7 @@ function appStateToUIStorePhase(state) {
   return phase
 }
 
+/**
 function peerCountsFromPluginStatuses(peerPluginStatuses) {
 
   // Counters
@@ -786,6 +814,7 @@ function peerCountsFromPluginStatuses(peerPluginStatuses) {
   }
 
 }
+*/
 
 /**
  startDownloadWithTorrentFileFromMagnetUri: function (client, magnetUri) {


### PR DESCRIPTION
Allows treating peer explicitly in the UI, and `TorrentStore` can now compute peer counts reactively.