### PR TITLE
WalletSceneStore - fix return statement in filteredPayments()

### DIFF
--- a/src/scenes/Wallet/Stores/WalletSceneStore.js
+++ b/src/scenes/Wallet/Stores/WalletSceneStore.js
@@ -64,7 +64,7 @@ class WalletSceneStore {
     let cryptoToFiatExchangeRate = parseFloat(this.priceFeedStore.cryptoToUsdExchangeRate)
     let paymentFailureErrorMessage = ''
     let minimumPaymentAmount = 0 // pass in dust limit
-    
+
     // Its critical that the actual fee rate is compatible with bcoin.util.isNumber, which requires that its a safe integer,
     // hence we just take ceiling to be sure.
     let satsPrKbFee = Math.ceil(this._satsPrkBFee)
@@ -137,7 +137,7 @@ class WalletSceneStore {
     else
       return this._walletStore.paymentStores.filter((paymentStore) => {
 
-        return
+        let foundMatchingPayment =
 
         // Match note
         (paymentStore.note && paymentStore.note.indexOf(this.searchString) != -1) ||
@@ -148,6 +148,8 @@ class WalletSceneStore {
         // Match txId
         (paymentStore.txId && paymentStore.txId.indexOf(this.searchString) != -1)
 
+
+        return foundMatchingPayment
     })
   }
 


### PR DESCRIPTION
fix return statement which will always return undefined because of the white space following it. (one of the quirks of javascript) This is a very common source of bugs that can be hard to spot.