### PR TITLE
Application: correctly add torrents from database

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -997,7 +997,7 @@ function encodeTorrentSettings(torrent) {
   }
 
   // Only encode metadata if it is available and valid
-  if (torrent.metadata && torrent.metadata.isValid()) {
+  if (torrent.torrentInfo && torrent.torrentInfo.isValid()) {
     encoded.metadata = torrent.metadata.toBencodedEntry().toString('base64')
   }
 

--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -998,7 +998,7 @@ function encodeTorrentSettings(torrent) {
 
   // Only encode metadata if it is available and valid
   if (torrent.torrentInfo && torrent.torrentInfo.isValid()) {
-    encoded.metadata = torrent.metadata.toBencodedEntry().toString('base64')
+    encoded.metadata = torrent.torrentInfo.toBencodedEntry().toString('base64')
   }
 
   // It is possible that resume data generation has failed and resumeData could be null

--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -374,12 +374,9 @@ class Application extends EventEmitter {
             savedTorrent.metadata = new TorrentInfo(Buffer.from(savedTorrent.metadata, 'base64'))
 
             // add to session
-            this._joystreamNodeSession.addTorrent(savedTorrent, (err, joystreamNodeTorrent) => {
+            this._addTorrent(savedTorrent, (err, torrent) => {
 
               assert(!err)
-
-              // Process that torrent was added to session
-              let torrent = this._onTorrentAddedToSession(savedTorrent, joystreamNodeTorrent)
 
               // When loaded, check if we are done loading all,
               // if so note this
@@ -567,16 +564,28 @@ class Application extends EventEmitter {
    */
   addTorrent(settings, onAdded = () => {}) {
 
+    if (this.state !== Application.STATE.STARTED) {
+      onAdded('Can add torrent when started')
+      return
+    }
+
+    this._addTorrent(settings, onAdded)
+  }
+
+  /**
+   * Add torrent with given settings
+   *
+   *
+   * @param settings {Object} - document ???
+   * @param fun {Func}  - Callback, returns {@link Torrent} on success, error string otherwise
+   */
+  _addTorrent(settings, onAdded = () => {}) {
+
     /**
      * There is a lot of weird copying and decoding going on here
      * which I don't want to break, but which should be fixed,
      * see:
      */
-
-    if (this.state !== Application.STATE.STARTED) {
-      onAdded('Can add torrent when started')
-      return
-    }
 
     const infoHash = settings.infoHash
 


### PR DESCRIPTION
The wrong argument was being passed to addTorrent method on joystream-node session.

Moved common code for adding torrent to session to "private" `_addTorrent` method.
The public `addTorrent` maintains guard so it is only used when application is in STARTED state.
