### PR TITLE
Fixed Media Player

### DIFF
--- a/src/components/VideoPlayer/CloseButton.js
+++ b/src/components/VideoPlayer/CloseButton.js
@@ -14,7 +14,7 @@ const CloseButton = observer((props) => {
     zIndex: 99
   }
 
-  const onClick = () => { props.torrent.close() }
+  // const onClick = () => { props.torrent.close() }
 
   return (
     <a style={closeStyle} onClick={props.onClick}></a>

--- a/src/components/VideoPlayer/StartPaidDownloadButton.js
+++ b/src/components/VideoPlayer/StartPaidDownloadButton.js
@@ -6,12 +6,12 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Provider, observer, inject } from 'mobx-react'
 
-import ViabilityOfPaidDownloadingTorrent from '../../scenes/Common/ViabilityOfPaidDownloadingTorrent'
-import ViabilityOfPaidDownloadingSwarm from '../../core/Torrent/ViabilityOfPaidDownloadingSwarm'
+// import ViabilityOfPaidDownloadingTorrent from '../../scenes/Common/ViabilityOfPaidDownloadingTorrent'
+// import ViabilityOfPaidDownloadingSwarm from '../../core/Torrent/ViabilityOfPaidDownloadingSwarm'
 
 function getColors(props, state) {
-
-    if (props.torrent.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart') {
+  if (props.torrent.isDownloading) {
+    if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart') {
 
         if (state.hover)
             return {
@@ -24,16 +24,19 @@ function getColors(props, state) {
                 background : 'rgba(92, 184, 92, 0.3)'
             }
 
-    } else if (props.torrent.viabilityOfPaidDownloadingTorrent.constructor.name === 'AlreadyStarted') {
+    } else if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'AlreadyStarted') {
         return {
             foreground : 'hsla(180, 1%, 80%, 0.6)',
             background : 'hsla(180, 1%, 80%, 0.4)'
         }
-    } else
-        return {
-            foreground : 'rgba(240, 173, 78, 1)',
-            background : 'rgba(240, 173, 78, 0.4)'
-        }
+    }
+  }
+
+  // not viable or torrent is already downloaded
+  return {
+      foreground : 'rgba(240, 173, 78, 1)',
+      background : 'rgba(240, 173, 78, 0.4)'
+  }
 
 }
 
@@ -156,7 +159,7 @@ class StartPaidDownloadButton extends Component {
 
         console.log('handleClick')
 
-        if(this.props.torrent.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart')
+        if(this.props.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart')
             this.props.torrent.startPaidDownload()
 
     }
@@ -164,7 +167,7 @@ class StartPaidDownloadButton extends Component {
     render() {
 
         let styles = getStyles(this.props, this.state)
-        let texts = getText(this.props.torrent.viabilityOfPaidDownloadingTorrent)
+        let texts = getText(this.props.viabilityOfPaidDownloadingTorrent)
 
         return (
             <div style={styles.root}

--- a/src/components/VideoPlayer/TorrentStreamProgress.js
+++ b/src/components/VideoPlayer/TorrentStreamProgress.js
@@ -157,7 +157,8 @@ const TorrentStreamProgress = observer((props) => {
             </div>
 
             <div style={styles.buttonContainer}>
-                <StartPaidDownloadButton torrent={props.mediaPlayerStore.torrent}/>
+                <StartPaidDownloadButton torrent={props.mediaPlayerStore.torrent}
+                       viabilityOfPaidDownloadingTorrent={props.mediaPlayerStore.viabilityOfPaidDownloadingTorrent} />
             </div>
 
         </div>

--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -772,7 +772,7 @@ class Application extends EventEmitter {
     torrent.on('Loading.WaitingForMissingBuyerTerms', (data) => {
 
       // NB: Replace by querying application settings later!
-      let terms = this.applicationSettings.buyerTerms()
+      let terms = this.applicationSettings.defaultBuyerTerms()
 
       // change name
       torrent.provideMissingBuyerTerms(terms)

--- a/src/core/Torrent/FileSegmentStreamFactory.js
+++ b/src/core/Torrent/FileSegmentStreamFactory.js
@@ -38,6 +38,8 @@ class FileSegmentStreamFactory {
 
     this.fileName = fileStorage.fileName(fileIndex)
 
+    this.name = this.fileName // render media is looking for this name property
+
     this.path = path.format({
       dir: this._torrent.handle.savePath(),
       base: fileStorage.filePath(fileIndex)

--- a/src/core/Torrent/Torrent.js
+++ b/src/core/Torrent/Torrent.js
@@ -274,7 +274,7 @@ class Torrent extends EventEmitter {
     let completed = this.state.startsWith('Active.FinishedDownloading')
 
     // Create factory and set
-    this.fileSegmentStreamFactory = new FileSegmentStreamFactory(client._joystreamNodeTorrent, fileIndex, completed)
+    this.fileSegmentStreamFactory = new FileSegmentStreamFactory(this._joystreamNodeTorrent, fileIndex, completed)
 
     return this.fileSegmentStreamFactory
   }

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -97,8 +97,11 @@ class TorrentTableRowStore {
     return this.playableMediaList.length > 0
   }
 
-  playMedia(fileIndex = 0) {
-    this._uiStore.playMedia(this.infoHash, fileIndex)
+  playMedia(/*fileIndex = 0*/) {
+    if (this.playableMediaList.length) {
+      let firstPlayableFileIndex = this.playableMediaList[0]
+      this._uiStore.playMedia(this.torrentStore, firstPlayableFileIndex)
+    }
   }
 
 }

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -19,10 +19,11 @@ class TorrentTableRowStore {
    */
   torrentStore
 
-  constructor(torrentStore, applicationStore, walletStore, showToolbar) {
+  constructor(torrentStore, uiStore, walletStore, showToolbar) {
 
     this.torrentStore = torrentStore
-    this._applicationStore = applicationStore
+    this._uiStore = uiStore
+    this._applicationStore = this._uiStore.applicationStore
     this._walletStore = walletStore
     this.setShowToolbar(showToolbar)
   }
@@ -84,14 +85,20 @@ class TorrentTableRowStore {
   @computed get
   playableMediaList() {
 
-    if(this.torrentStore.torrentInfo) {
-      return indexesOfPlayableFiles(this.torrentStore.torrentInfo.torrentFiles)
-    } else
+    if(this.torrentStore.torrentFiles) {
+      return indexesOfPlayableFiles(this.torrentStore.torrentFiles)
+    } else {
       return []
+    }
+  }
+
+  @computed get
+  canPlayMedia () {
+    return this.playableMediaList.length > 0
   }
 
   playMedia(fileIndex = 0) {
-    this.torrentStore.play(this.playableMediaList[fileIndex])
+    this._uiStore.playMedia(this.infoHash, fileIndex)
   }
 
 }

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -100,7 +100,7 @@ class TorrentTableRowStore {
   playMedia(/*fileIndex = 0*/) {
     if (this.playableMediaList.length) {
       let firstPlayableFileIndex = this.playableMediaList[0]
-      this._uiStore.playMedia(this.torrentStore, firstPlayableFileIndex)
+      this._uiStore.playMedia(this.torrentStore.infoHash, firstPlayableFileIndex)
     }
   }
 

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -19,12 +19,12 @@ class TorrentTableRowStore {
    */
   torrentStore
 
-  constructor(torrentStore, uiStore, walletStore, showToolbar) {
+  constructor(torrentStore, uiStore, showToolbar) {
 
     this.torrentStore = torrentStore
     this._uiStore = uiStore
     this._applicationStore = this._uiStore.applicationStore
-    this._walletStore = walletStore
+    this._walletStore = this._applicationStore.walletStore
     this.setShowToolbar(showToolbar)
   }
 

--- a/src/scenes/Completed/Stores/CompletedStore.js
+++ b/src/scenes/Completed/Stores/CompletedStore.js
@@ -22,7 +22,7 @@ class CompletedStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore.applicationStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/Completed/Stores/CompletedStore.js
+++ b/src/scenes/Completed/Stores/CompletedStore.js
@@ -22,7 +22,7 @@ class CompletedStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -49,7 +49,7 @@ class DownloadingStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore.applicationStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -49,7 +49,7 @@ class DownloadingStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/Downloading/components/TorrentToolbar.js
+++ b/src/scenes/Downloading/components/TorrentToolbar.js
@@ -17,14 +17,14 @@ import Toolbar, {
 import TorrentTableRowStore from '../../Common/TorrentTableRowStore'
 
 const TorrentToolbar = observer((props) => {
-  
+
   return (
     <Toolbar>
 
-      <PlaySection canPlay={props.torrentTableRowStore.playableMediaList.length > 0}
+      <PlaySection canPlay={props.torrentTableRowStore.canPlayMedia}
                    play={() => { props.torrentTableRowStore.playMedia() }}
       />
-      
+
       <StartPaidDownloadingSection row={props.torrentTableRowStore} />
 
       <ToggleStatusSection canStart={props.torrentTableRowStore.torrentStore.canStart}

--- a/src/scenes/Seeding/Stores/UploadingStore.js
+++ b/src/scenes/Seeding/Stores/UploadingStore.js
@@ -65,7 +65,7 @@ class UploadingStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/Seeding/Stores/UploadingStore.js
+++ b/src/scenes/Seeding/Stores/UploadingStore.js
@@ -65,7 +65,7 @@ class UploadingStore {
     if(this.rowStorefromTorrentInfoHash.has(torrentStore.infoHash))
       throw Error('Torrent store for same torrent already exists.')
 
-    let row = new TorrentTableRowStore(torrentStore, this._uiStore.applicationStore, this._uiStore.applicationStore.walletStore, false)
+    let row = new TorrentTableRowStore(torrentStore, this._uiStore, this._uiStore.applicationStore.walletStore, false)
 
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -439,6 +439,7 @@ class UIStore {
 
       torrentStore.setName(torrentInfo.name())
       torrentStore.setTotalSize(torrentInfo.totalSize())
+      torrentStore.setTorrentFiles(torrentInfo.files())
     }))
 
     // When torrent is finished, we have to count towards the navigator
@@ -562,7 +563,12 @@ class UIStore {
       torrentStore.peerStores.delete(peerId)
 
     }))
-    
+
+    // If we have metadata set the torrentFiles
+    if (torrent.torrentInfo && torrent.torrentInfo.isValid()) {
+      torrentStore.setTorrentFiles(torrent.torrentInfo.files())
+    }
+
     // Add to application store
     this.applicationStore.onNewTorrentStore(torrentStore)
 

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -85,19 +85,19 @@ class UIStore {
    * session
    */
   @observable numberOfPiecesSoldAsSeller
-  
+
   /**
    * {Number} Total revenue so far from spending, does not include
    * tx fees for closing channel (they are deducted).
    */
   @observable totalRevenueFromPieces
-  
+
   /**
    * {Number} The total amount (sats) sent as payments so far,
    * does not include tx fees used to open and close channel.
    */
   @observable totalSpendingOnPieces
-  
+
   /**
    * {ApplicationNavigationStore} Model for application navigator.
    * Is set when `currentPhase` is `PHASE.Alive`.
@@ -182,7 +182,7 @@ class UIStore {
 
     application.on('state', this._onNewApplicationStateAction)
     this._onNewApplicationStateAction(application.state)
-    
+
     // NB: We only hook into `resourceStarted` and `resourceStopped`,
     // not `startedResources`, as they are redundant w.r.t. the same canonical
     // state change, and this opens up the possibility of race conditions in updating
@@ -191,9 +191,9 @@ class UIStore {
     application.on('resourceStarted', this._onResourceStartedAction)
     for(const resource of application.startedResources)
       this._onResourceStartedAction(resource)
-    
+
     application.on('resourceStopped', this._onResourceStoppedAction)
-    
+
     application.on('onboardingIsEnabled', this._updateOnboardingStatusAction)
     this._updateOnboardingStatusAction(application.onboardingIsEnabled)
 
@@ -207,18 +207,18 @@ class UIStore {
   }
 
   _onNewApplicationStateAction = action((newState) => {
-    
+
     this.applicationStore.setState(newState)
     this.setCurrentPhase(appStateToUIStorePhase(newState))
 
     if(newState === Application.STATE.STARTING) {
-  
+
       /**
        * Create UI stores that must be available in order to
        * do basic UI of the app, which is possible at the earliest
        * while the application is starting.
        */
-  
+
       // Application header
       this.applicationNavigationStore = new ApplicationNavigationStore(
         this,
@@ -227,88 +227,88 @@ class UIStore {
         'USD',
         bcoin.protocol.consensus.COIN
       )
-  
+
       // Scene specific stores
       this.uploadingStore = new UploadingStore(this)
       this.downloadingStore = new DownloadingStore(this)
       this.completedStore = new CompletedStore(this)
-  
+
       // add existing torrents to scene stores
-      
+
       this.applicationStore.torrentStores.forEach((torrentStore, infoHash) => {
-    
+
         this.uploadingStore.addTorrentStore(torrentStore)
         this.downloadingStore.addTorrentStore(torrentStore)
         this.completedStore.addTorrentStore(torrentStore)
-    
+
       })
-      
+
       // Imperatively display doorbell widget
       Doorbell.load()
-    
+
     } else if(newState === Application.STATE.STARTED) {
-  
+
       /**
        * Is there really anything to do here any more?
        */
-      
+
     }
     else if(newState === Application.STATE.STOPPING) {
       // hide doorbell again
       Doorbell.hide()
     }
-    
+
   })
-  
+
   _onResourceStartedAction = action((resource) => {
-  
+
     // Update started resource set
     this.applicationStore.setStartedResources(resource)
-    
+
     if(resource === Application.RESOURCE.SETTINGS) {
-  
+
       /**
        * ApplicationSettings
        * Nothing much to do here beyond exposing it, since there is no actual store
        */
-  
+
       let applicationSettings = this._application.applicationSettings
       assert(applicationSettings)
-      
+
       assert(!this.applicationStore.applicationSettings)
       this.applicationStore.applicationSettings = applicationSettings
-      
+
     } else if(resource === Application.RESOURCE.PRICE_FEED) {
-  
+
       /**
        * Create and setup price feed store
        */
-  
+
       let priceFeed = this._application.priceFeed
       assert(priceFeed)
-  
+
       // Create
       assert(!this.applicationStore.priceFeedStore)
       this.applicationStore.priceFeedStore = new PriceFeedStore(priceFeed.cryptoToUsdExchangeRate)
-  
+
       // Hook into events
       priceFeed.on('tick', action((cryptoToUsdExchangeRate) => {
-    
+
         this.applicationStore.priceFeedStore.setCryptoToUsdExchangeRate(cryptoToUsdExchangeRate)
       }))
-      
+
     } else if(resource === Application.RESOURCE.WALLET) {
-      
+
       /**
        * Create and setup wallet store
        */
-    
+
       let wallet = this._application.wallet
       assert(wallet)
-      
+
       // Create walletStore
       assert(!this.applicationStore.walletStore)
-      
+
       this.applicationStore.walletStore = new WalletStore(
         wallet.state,
         wallet.totalBalance,
@@ -319,7 +319,7 @@ class UIStore {
         [],
         wallet.pay.bind(wallet)
       )
-    
+
       // Hook into events
       wallet.on('stateChanged', this._onWalletStateChanged)
       wallet.on('totalBalanceChanged', this._onWalletTotalBalanceChanged)
@@ -328,12 +328,12 @@ class UIStore {
       wallet.on('blockTipHeightChanged', this._onWalletBlockTipHeightChanged)
       wallet.on('synchronizedBlockHeightChanged', this._onWalletSynchronizedBlockHeightChanged)
       wallet.on('paymentAdded', this._onWalletPaymentAdded)
-      
+
       // add any payments which are already present
       wallet.paymentsInTransactionWithTXID.forEach((payments, txHash) => {
           payments.forEach(this._onWalletPaymentAdded.bind(this))
       })
-      
+
       /**
        * Set wallet scene model
        * For now just set a constant fee rate, in the
@@ -342,7 +342,7 @@ class UIStore {
        * Estimate picked from: https://live.blockcypher.com/btc-testnet/
        */
       let satsPrkBFee = 0.00239 * bcoin.protocol.consensus.COIN
-      
+
       assert(!this.walletSceneStore)
       this.walletSceneStore = new WalletSceneStore(
         this.applicationStore.walletStore,
@@ -352,16 +352,16 @@ class UIStore {
         '',
         launchExternalTxViewer
       )
-    
+
     }
-  
+
   })
-  
+
   _onResourceStoppedAction = action((resource) => {
-  
+
     // Update started resource set
     this.applicationStore.setStartedResources(resource)
-    
+
   })
 
 
@@ -500,33 +500,33 @@ class UIStore {
        */
 
       torrentStore.totalSpendingOnPiecesAsBuyer += paymentIncrement
-      
+
       // Global counters
       this.totalSpendingOnPieces += paymentIncrement
     }))
-    
+
     torrent.on('validPaymentReceived', action((paymentIncrement, totalNumberOfPayments, totalAmountPaid) => {
-      
+
       torrentStore.numberOfPiecesSoldAsSeller++
       torrentStore.totalRevenueFromPiecesAsSeller += paymentIncrement
-      
+
       // Global counters
       this.numberOfPiecesSoldAsSeller++
       this.totalRevenueFromPieces += paymentIncrement
     }))
-    
+
     torrent.on('lastPaymentReceived', action((settlementTx) => {
-      
+
       // Raw transaction
       console.log('settlementTx')
       console.log(settlementTx)
-      
+
     }))
-  
+
     torrent.on('failedToMakeSignedContract', action((failedToMakeSignedContract) => {
       console.log('failedToMakeSignedContract: ' + failedToMakeSignedContract)
     }))
-    
+
     /**
      * When a peer is added,
      * we create a peer store which watches the peer and
@@ -577,7 +577,7 @@ class UIStore {
     // which they only do when UI is active, not during loading
 
     if(this.currentPhase === UIStore.PHASE.Alive) {
-      
+
       assert(this.uploadingStore)
       assert(this.downloadingStore)
       assert(this.completedStore)
@@ -588,12 +588,12 @@ class UIStore {
        * the torrent may be in an irrelevant state. This avoids
        * having to add/remove through reactions as state changes
        */
-      
+
       this.uploadingStore.addTorrentStore(torrentStore)
       this.downloadingStore.addTorrentStore(torrentStore)
       this.completedStore.addTorrentStore(torrentStore)
     }
-    
+
   })
 
   _onTorrentRemovedAction = action((infoHash) => {
@@ -765,17 +765,10 @@ class UIStore {
   playMedia(torrentStore, fileIndex) {
 
     // state guard?
-    console.log('trying to play media for torrent', torrentStore.infoHash)
 
     assert(this._application.torrents.has(torrentStore.infoHash))
 
     const torrent = this._application.torrents.get(torrentStore.infoHash)
-
-    // Hide feedback in player
-    Doorbell.hide()
-
-    // Turn on power saving blocker
-    powerSavingBlocker(true)
 
     // Create store for player
     const mediaSourceType = torrentStore.isFullyDownloaded ? MediaPlayerStore.MEDIA_SOURCE_TYPE.DISK : MediaPlayerStore.MEDIA_SOURCE_TYPE.STREAMING_TORRENT
@@ -802,6 +795,12 @@ class UIStore {
 
     // Display the media player
     this.setMediaPlayerStore(store)
+
+    // Hide feedback in player
+    Doorbell.hide()
+
+    // Turn on power saving blocker
+    powerSavingBlocker(true)
   }
 
   @computed get
@@ -839,14 +838,14 @@ class UIStore {
   }
 
   @computed get torrentsBeingTerminated() {
-    
+
     return this.torrentStoresArray.filter(function (torrent) {
       return torrent.isTerminating
     })
   }
 
   @computed get terminatingTorrentsProgressPercentage() {
-    
+
     return this.torrentsBeingTerminated * 100 / this.applicationStore.torrentStores.size
   }
 

--- a/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
+++ b/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
@@ -116,17 +116,16 @@ class MediaPlayerStore {
      * @param loadedTimeRequiredForPlayback {Number} - seconds of media data required before playback is allowed
      */
     constructor(mediaSourceType,
-                torrent,
+                torrentStore,
                 file,
                 loadedTimeRequiredForPlayback,
                 autoPlay,
                 mediaPlayerWindowSizeFetcher,
                 mediaPlayerWindowSizeUpdater,
-                powerSavingBlocker,
-                showDoorbellWidget) {
+                onExit) {
 
         this.mediaSourceType = mediaSourceType
-        this.torrent = torrent
+        this.torrent = torrentStore
         this.file = file
         this._loadedTimeRequiredForPlayback = loadedTimeRequiredForPlayback
         this.autoPlay = autoPlay
@@ -134,8 +133,7 @@ class MediaPlayerStore {
         // Hold on to callbacks to static resources
         this._mediaPlayerWindowSizeFetcher = mediaPlayerWindowSizeFetcher
         this._mediaPlayerWindowSizeUpdater = mediaPlayerWindowSizeUpdater
-        this._powerSavingBlocker = powerSavingBlocker
-        this._showDoorbellWidget = showDoorbellWidget
+        this._onExit = onExit
 
         //this.setVideoIsPlaying(false)
 
@@ -188,9 +186,6 @@ class MediaPlayerStore {
 
         // Adjust window size to match media dimensions
         this._mediaPlayerWindowSizeUpdater({width: event.target.videoWidth, height: event.target.videoHeight})
-
-        // Turn on power saving blocking
-        this._powerSavingBlocker(true)
     }
 
     @action.bound
@@ -277,18 +272,12 @@ class MediaPlayerStore {
     @action.bound
     exit() {
 
-        // Reset media player store
-        this.torrent.setActiveMediaPlayerStore(null)
-
         // Adjust window size back to old dimensions, if it has been resized
         if(this._windowSizePriorToResize)
             this._mediaPlayerWindowSizeUpdater({width: this._windowSizePriorToResize.width, height: this._windowSizePriorToResize.height})
 
-        // Turn off power saving blocking
-        this._powerSavingBlocker(false)
-
-        // Show doorbell again
-        this._showDoorbellWidget()
+        // Infrom UI we are exiting
+        this._onExit()
     }
 
     @computed get

--- a/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
+++ b/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
@@ -122,7 +122,8 @@ class MediaPlayerStore {
                 autoPlay,
                 mediaPlayerWindowSizeFetcher,
                 mediaPlayerWindowSizeUpdater,
-                onExit) {
+                onExit,
+                uiStore) {
 
         this.mediaSourceType = mediaSourceType
         this.torrent = torrentStore
@@ -141,6 +142,8 @@ class MediaPlayerStore {
         // we must keep track of this in order to adjust
         // size back
         this._windowSizePriorToResize = null
+
+        this._uiStore = uiStore
     }
 
     @action.bound
@@ -291,7 +294,10 @@ class MediaPlayerStore {
             return 0
     }
 
-
+    @computed get
+    viabilityOfPaidDownloadingTorrent() {
+      return this._uiStore.downloadingTorrentsViabilityOfPaidDownloading.get(this.torrent.infoHash)
+    }
 }
 
 function playbackTimeAvailable(currentTime, timeRanges) {

--- a/test/ui/CompletedStore/index.js
+++ b/test/ui/CompletedStore/index.js
@@ -4,14 +4,10 @@ import TorrentStore from '../../../src/core-stores/Torrent'
 
 var assert = require('chai').assert
 
-const createInitialValues = () => {
-  return [
-    { // UIStore
-      applicationStore: {
-        walletStore: {}
-      }
-    }
-  ]
+const mockUIStore = {
+  applicationStore: {
+    walletStore: {}
+  }
 }
 
 function initStoreWithOneTorrent (store, infoHash) {
@@ -22,18 +18,17 @@ function initStoreWithOneTorrent (store, infoHash) {
     state: 'Active.FinishedDownloading'
   })
 
-  map.set(infoHash, new TorrentTableRowStore(torrentStore))
+  map.set(infoHash, new TorrentTableRowStore(torrentStore, mockUIStore))
 
   store.setRowStorefromTorrentInfoHash(map)
 }
 
 describe('CompletedStore', function () {
-  let completedStore, initialValues
+  let completedStore
   const infoHash1 = 'infoHash-1'
 
   beforeEach(function () {
-    initialValues = createInitialValues()
-    completedStore = new CompletedStore(...initialValues)
+    completedStore = new CompletedStore(mockUIStore)
   })
 
   it('constructor initializes empty infoHash to TorrentTableRowStore map', function () {

--- a/test/ui/DownloadingStore/index.js
+++ b/test/ui/DownloadingStore/index.js
@@ -4,14 +4,10 @@ import TorrentStore from '../../../src/core-stores/Torrent'
 
 var assert = require('chai').assert
 
-const createInitialValues = () => {
-  return [
-    { // UIStore
-      applicationStore: {
-        walletStore: {}
-      }
-    }
-  ]
+const mockUIStore = {
+  applicationStore: {
+    walletStore: {}
+  }
 }
 
 function initStoreWithOneTorrent (store, infoHash) {
@@ -22,18 +18,17 @@ function initStoreWithOneTorrent (store, infoHash) {
     state: 'Active.DownloadIncomplete'
   })
 
-  map.set(infoHash, new TorrentTableRowStore(torrentStore))
+  map.set(infoHash, new TorrentTableRowStore(torrentStore, mockUIStore))
 
   store.setRowStorefromTorrentInfoHash(map)
 }
 
 describe('DownloadingStore', function () {
-  let downloadingStore, initialValues
+  let downloadingStore
   const infoHash1 = 'infoHash-1'
 
   beforeEach(function () {
-    initialValues = createInitialValues()
-    downloadingStore = new DownloadingStore(...initialValues)
+    downloadingStore = new DownloadingStore(mockUIStore)
   })
 
   it('constructor initializes empty infoHash to TorrentTableRowStore map', function () {

--- a/test/ui/UploadingStore/index.js
+++ b/test/ui/UploadingStore/index.js
@@ -4,14 +4,10 @@ import TorrentStore from '../../../src/core-stores/Torrent'
 
 var assert = require('chai').assert
 
-const createInitialValues = () => {
-  return [
-    { // UIStore
-      applicationStore: {
-        walletStore: {}
-      }
-    }
-  ]
+const mockUIStore = {
+  applicationStore: {
+    walletStore: {}
+  }
 }
 
 function initStoreWithOneTorrent (store, infoHash) {
@@ -22,18 +18,17 @@ function initStoreWithOneTorrent (store, infoHash) {
     state: 'Active.FinishedDownloading.Uploading'
   })
 
-  map.set(infoHash, new TorrentTableRowStore(torrentStore))
+  map.set(infoHash, new TorrentTableRowStore(torrentStore, mockUIStore))
 
   store.setRowStorefromTorrentInfoHash(map)
 }
 
 describe('UploadingStore', function () {
-  let uploadingStore, initialValues
+  let uploadingStore
   const infoHash1 = 'infoHash-1'
 
   beforeEach(function () {
-    initialValues = createInitialValues()
-    uploadingStore = new UploadingStore(...initialValues)
+    uploadingStore = new UploadingStore(mockUIStore)
   })
 
   it('constructor initializes empty infoHash to TorrentTableRowStore map', function () {


### PR DESCRIPTION
- [x] Fix `play` action button on torrent toolbar 
   - compute playable media files when metadata is available
   - invoke `playMedia` action on UIStore
- [x] Implement `playMedia` action on UIStore to render MediaPlayer

I also made an attempt to do computation of paid download viability on the UIStore. The computed value (a map of infoHash to viability) can be used in other stores to check the viability. This way we don't have to pass the wallet store and replicate code in other stores that need it.