### PR TITLE
Improve viability computation

### DIFF
--- a/src/components/VideoPlayer/StartPaidDownloadButton.js
+++ b/src/components/VideoPlayer/StartPaidDownloadButton.js
@@ -6,30 +6,26 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { Provider, observer, inject } from 'mobx-react'
 
-// import ViabilityOfPaidDownloadingTorrent from '../../scenes/Common/ViabilityOfPaidDownloadingTorrent'
-// import ViabilityOfPaidDownloadingSwarm from '../../core/Torrent/ViabilityOfPaidDownloadingSwarm'
-
 function getColors(props, state) {
-  if (props.torrent.isDownloading) {
-    if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart') {
 
-        if (state.hover)
-            return {
-                foreground : 'rgba(92, 254, 92, 0.7)',
-                background : 'rgba(92, 254, 92, 0.4)'
-            }
-        else
-            return {
-                foreground : 'rgba(92, 184, 92, 0.7)',
-                background : 'rgba(92, 184, 92, 0.3)'
-            }
+  if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart') {
+      if (state.hover) {
+          return {
+              foreground : 'rgba(92, 254, 92, 0.7)',
+              background : 'rgba(92, 254, 92, 0.4)'
+          }
+      } else {
+          return {
+              foreground : 'rgba(92, 184, 92, 0.7)',
+              background : 'rgba(92, 184, 92, 0.3)'
+          }
+      }
 
-    } else if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'AlreadyStarted') {
-        return {
-            foreground : 'hsla(180, 1%, 80%, 0.6)',
-            background : 'hsla(180, 1%, 80%, 0.4)'
-        }
-    }
+  } else if (props.viabilityOfPaidDownloadingTorrent.constructor.name === 'AlreadyStarted') {
+      return {
+          foreground : 'hsla(180, 1%, 80%, 0.6)',
+          background : 'hsla(180, 1%, 80%, 0.4)'
+      }
   }
 
   // not viable or torrent is already downloaded
@@ -116,9 +112,13 @@ function getText(viabilityOfPaidDownloadingTorrent) {
                 subText = "Insufficient number of sellers have joined"
             else if(viabilityOfPaidDownloadingTorrent.swarmViability.constructor.name === 'Viable')
                 assert(false) // <== not possible
-
-        } else
+        } else if (viabilityOfPaidDownloadingTorrent.constructor.name === 'NotLoaded') {
+            assert(false, 'Media Player should not have been started for a that is torrent still loading')
+        } else if (viabilityOfPaidDownloadingTorrent.constructor.name === 'FullyDownloaded') {
+            assert(false, 'Media Player should not show start paid download button for a fully downloaded torrent')
+        } else {
             assert(false) // <== not possible
+        }
     }
 
     return {

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -1,8 +1,7 @@
 
 import { observable, action } from 'mobx'
-import {computed} from "mobx/lib/mobx";
-import {indexesOfPlayableFiles, computeViabilityOfPaidDownloadingTorrent} from './utils'
-import Wallet from '../../core/Wallet'
+import {computed} from 'mobx/lib/mobx'
+import {indexesOfPlayableFiles} from './utils'
 
 /**
  * Model for row in downloading table
@@ -24,7 +23,6 @@ class TorrentTableRowStore {
     this.torrentStore = torrentStore
     this._uiStore = uiStore
     this._applicationStore = this._uiStore.applicationStore
-    this._walletStore = this._applicationStore.walletStore
     this.setShowToolbar(showToolbar)
   }
 
@@ -55,31 +53,9 @@ class TorrentTableRowStore {
     shell.openItem(this.torrentStore.savePath)
   }
 
-  /**
-   *
-   * NB: Possible hack note
-   *
-   * Its not clear that this should live here, because it will need to be
-   * computed different places in the UI stores hierarchy, which violates the "single
-   * source of truth" principle. On the other hand, we have no torrent level
-   * representation which would otherwise hold this. The `TorrentStore` has to
-   * match the `Torrent`, hence we would need ot add this to that class, but that also seems wrong
-   * A brighter mind should review this.
-   *
-   */
-
   @computed get
   viabilityOfPaidDownloadingTorrent() {
-
-    let balance = 0
-    let walletStarted = false
-
-    if (this._walletStore) {
-      balance = this._walletStore.totalBalance
-      walletStarted = this._walletStore.state === Wallet.STATE.STARTED
-    }
-
-    return computeViabilityOfPaidDownloadingTorrent(this.torrentStore.state, walletStarted, balance, this.torrentStore.viabilityOfPaidDownloadInSwarm)
+    return this._uiStore.torrentsViabilityOfPaidDownloading.get(this.torrentStore.infoHash)
   }
 
   @computed get

--- a/src/scenes/Common/ViabilityOfPaidDownloadingTorrent.js
+++ b/src/scenes/Common/ViabilityOfPaidDownloadingTorrent.js
@@ -25,6 +25,13 @@ function CanStart(suitablePeers, estimate) {
     this.estimate = estimate
 }
 
+// Torrent is still being loaded
+function NotLoaded() {
+}
+
+// Torrent is fully downloaded and it doesn't make sense to pay for it
+function FullyDownloaded() {
+}
 
 export {
   Stopped,
@@ -32,5 +39,7 @@ export {
   InViable,
   WalletNotReady,
   InsufficientFunds,
-  CanStart
+  CanStart,
+  NotLoaded,
+  FullyDownloaded
 }

--- a/src/scenes/Common/utils.js
+++ b/src/scenes/Common/utils.js
@@ -8,7 +8,9 @@ import {
   WalletNotReady,
   InsufficientFunds,
   InViable,
-  Stopped
+  Stopped,
+  NotLoaded,
+  FullyDownloaded
 } from './ViabilityOfPaidDownloadingTorrent'
 import {ViabilityOfPaidDownloadInSwarm} from '../../core/Torrent'
 
@@ -47,10 +49,13 @@ function indexesOfPlayableFiles(torrentFiles) {
  * @param state {String} - state of torrent
  * @param walletStarted {Boolean} - whether wallet has currently been started
  * @param balance {Number} -  (stats)
- * @returns {Stopped|AlreadyStarted|InViable|WalletNotReady|InsufficientFunds|CanStart}
+ * @returns {Stopped|AlreadyStarted|InViable|WalletNotReady|InsufficientFunds|CanStart|NotStarted|FullyDownloaded}
  */
 function computeViabilityOfPaidDownloadingTorrent(state, walletStarted, balance, viabilityOfPaidDownloadInSwarm) {
-  
+  if(state.startsWith('Loading'))
+    return new NotLoaded()
+  if(state.startsWith('Active.FinishedDownloading'))
+    return new FullyDownloaded()
   if(state.startsWith("Active.DownloadIncomplete.Unpaid.Stopped"))
     return new Stopped()
   else if(state.startsWith("Active.DownloadIncomplete.Paid"))
@@ -60,10 +65,10 @@ function computeViabilityOfPaidDownloadingTorrent(state, walletStarted, balance,
   else if(!walletStarted)
     return new WalletNotReady()
   else {
-    
+
     // Here it must be that swarm is viable, by
     // test in prior step
-    
+
     if(balance == 0) // <== fix later to be a more complex constraint
       return new InsufficientFunds(viabilityOfPaidDownloadInSwarm.estimate, balance)
     else

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -869,8 +869,7 @@ class UIStore {
   }
 
   @computed get
-  downloadingTorrentsViabilityOfPaidDownloading () {
-    let viabilities = new Map()
+  torrentsViabilityOfPaidDownloading () {
     let balance = 0
     let walletStarted = false
     const walletStore = this.applicationStore.walletStore
@@ -880,15 +879,11 @@ class UIStore {
       walletStarted = walletStore.state === Wallet.STATE.STARTED
     }
 
-    this.torrentStoresArray.forEach(function (torrent) {
-      if (!torrent.isDownloading) return
+    return new Map(this.torrentStoresArray.map(function (torrent) {
+      const viability = computeViabilityOfPaidDownloadingTorrent(torrent.state, walletStarted, balance, torrent.viabilityOfPaidDownloadInSwarm)
 
-      let viability = computeViabilityOfPaidDownloadingTorrent(torrent.state, walletStarted, balance, torrent.viabilityOfPaidDownloadInSwarm)
-
-      viabilities.set(torrent.infoHash, viability)
-    })
-
-    return viabilities
+      return [torrent.infoHash, viability]
+    }))
   }
 
   @action.bound

--- a/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
+++ b/src/scenes/VideoPlayer/Stores/MediaPlayerStore.js
@@ -296,7 +296,7 @@ class MediaPlayerStore {
 
     @computed get
     viabilityOfPaidDownloadingTorrent() {
-      return this._uiStore.downloadingTorrentsViabilityOfPaidDownloading.get(this.torrent.infoHash)
+      return this._uiStore.torrentsViabilityOfPaidDownloading.get(this.torrent.infoHash)
     }
 }
 


### PR DESCRIPTION
Review and merge https://github.com/JoyStream/joystream-desktop/pull/712 first

Adding two new values to ViabilityOfPaidDownloadingTorrent: `NotLoaded`, `FullyDownloaded`
We now compute viability for all torrents.
Reused computed map in TorrentTableRowStore