### PR TITLE
Fix Downloading Progress Bar

### DIFF
--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -468,7 +468,7 @@ class UIStore {
     }))
 
     torrent.on('progress', action((progress) => {
-      torrentStore.setProgress(progress)
+      torrentStore.setProgress(progress * 100)
     }))
 
     torrent.on('downloadedSize', action((downloadedSize) => {


### PR DESCRIPTION
covert progress of torrent to value between 0 and 100 for the ui component (default max=100 and min=0). progress from libtorrent is a value betwen 0 and 1