### PR TITLE
Final torrent scenes fix

### DIFF
--- a/src/components/Toolbar/StartUploadingSection.js
+++ b/src/components/Toolbar/StartUploadingSection.js
@@ -14,9 +14,9 @@ const StartUploadingSection = observer((props) => {
     let className
 
     let onClick
-    if(props.torrent.canBeginUploading) {
+    if(props.canBeginPaidUploadWidthDefaultTerms) {
         className = "start-sell"
-        onClick = () => { props.torrent.beginUploading() } // terms?????
+        onClick = props.onClick
     } else {
         className = "start-sell-disabled"
         onClick = null
@@ -30,7 +30,8 @@ const StartUploadingSection = observer((props) => {
 })
 
 StartUploadingSection.propTypes = {
-    torrent : PropTypes.object.isRequired, // TorrentStore really
+  canBeginPaidUploadWidthDefaultTerms : PropTypes.bool.isRequired,
+  onClick : PropTypes.func.isRequired
 }
 
 export default StartUploadingSection

--- a/src/core-stores/Application/ApplicationStore.js
+++ b/src/core-stores/Application/ApplicationStore.js
@@ -143,7 +143,7 @@ class ApplicationStore {
       this._pendingAddTorrentCallsMap.delete(infoHash)
 
       // make call
-      userCallback()
+      userCallback(null, torrentStore)
     }
 
   }
@@ -172,7 +172,7 @@ class ApplicationStore {
       this._pendingRemoveTorrentCallsMap.delete(infoHash)
 
       // make call
-      userCallback()
+      userCallback(null)
     }
 
   }

--- a/src/core-stores/Application/ApplicationStore.js
+++ b/src/core-stores/Application/ApplicationStore.js
@@ -199,7 +199,18 @@ class ApplicationStore {
     this._pendingAddTorrentCallsMap.set(settings.infoHash, onTorrentStoreAdded)
 
     // Add
-    this._torrentAdder(settings)
+    this._torrentAdder(settings, (err, torrent) => {
+  
+      /**
+       * The only reason we handle this callback is to catch when there is
+       * a possible failure. In a success scenario, we must wait for the underlying
+       * domain state manager to construct a `TorrentStore` instance and call
+       * `onNewTorrentStore`
+       */
+      
+      if(err)
+        onTorrentStoreAdded(err)
+    })
   }
 
   @action.bound

--- a/src/core-stores/Torrent/TorrentStore.js
+++ b/src/core-stores/Torrent/TorrentStore.js
@@ -323,8 +323,8 @@ class TorrentStore {
         this._paidDownloadStarter()
     }
 
-    beginUploading() {
-        this._uploadBeginner()
+    beginUploading(sellerTerms) {
+        this._uploadBeginner(sellerTerms)
     }
 
     endUploading() {

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -81,6 +81,13 @@ class TorrentTableRowStore {
     }
   }
 
+  beginPaidUploadWithDefaultTerms() {
+
+    let defaultTerms = this._uiStore.applicationStore.applicationSettings.defaultSellerTerms()
+
+    this.torrentStore.beginUploading(defaultTerms)
+  }
+
 }
 
 export default TorrentTableRowStore

--- a/src/scenes/Completed/components/TorrentRow.js
+++ b/src/scenes/Completed/components/TorrentRow.js
@@ -11,7 +11,6 @@ import {
 } from '../../../components/RowFields'
 import TorrentToolbar from './TorrentToolbar'
 import AbsolutePositionChildren from '../../../components/AbsolutePositionChildren/AbsolutePositionChildren'
-import {TorrentTableRowStore} from "../../Common";
 
 const TorrentRow = observer((props) => {
   
@@ -21,7 +20,7 @@ const TorrentRow = observer((props) => {
     <Row
       onMouseEnter={() => { props.torrentTableRowStore.setShowToolbar(true) }}
       onMouseLeave={() => { props.torrentTableRowStore.setShowToolbar(false) }}
-      style={ {backgroundColor : props.backgroundColor}}
+      backgroundColor={props.backgroundColor}
     >
       <NameField name={torrentStore.name} />
       
@@ -47,6 +46,7 @@ const TorrentRow = observer((props) => {
 
 TorrentRow.propTypes = {
   torrentTableRowStore: PropTypes.object.isRequired, // HMR breaks => PropTypes.instanceOf(TorrentTableRowStore).isRequired,
+  backgroundColor: PropTypes.string
 }
 
 export default TorrentRow

--- a/src/scenes/Completed/components/TorrentRow.js
+++ b/src/scenes/Completed/components/TorrentRow.js
@@ -46,7 +46,7 @@ const TorrentRow = observer((props) => {
 })
 
 TorrentRow.propTypes = {
-  torrentTableRowStore: PropTypes.instanceOf(TorrentTableRowStore).isRequired
+  torrentTableRowStore: PropTypes.object.isRequired, // HMR breaks => PropTypes.instanceOf(TorrentTableRowStore).isRequired,
 }
 
 export default TorrentRow

--- a/src/scenes/Completed/components/TorrentTable.js
+++ b/src/scenes/Completed/components/TorrentTable.js
@@ -39,7 +39,7 @@ const TorrentsTable = observer((props) => {
 })
 
 TorrentsTable.propTypes = {
-  completedStore : PropTypes.instanceOf(CompletedStore).isRequired
+  completedStore : PropTypes.object.isRequired // HMR is breaks => PropTypes.instanceOf(CompletedStore).isRequired
 }
 
 export default TorrentsTable

--- a/src/scenes/Completed/components/TorrentToolbar.js
+++ b/src/scenes/Completed/components/TorrentToolbar.js
@@ -18,7 +18,9 @@ const TorrentToolbar = (props) => {
                    play={() => { props.torrentTableRowStore.playMedia() }}
       />
       
-      <StartUploadingSection torrent={props.torrentTableRowStore.torrentStore} />
+      <StartUploadingSection canBeginPaidUploadWidthDefaultTerms={props.torrentTableRowStore.torrentStore.canBeginUploading}
+                             onClick={() => { props.torrentTableRowStore.beginPaidUploadWithDefaultTerms() }}
+      />
       
       <RemoveSection onClick={() => { props.torrentTableRowStore.remove() }} />
       

--- a/src/scenes/Completed/components/TorrentToolbar.js
+++ b/src/scenes/Completed/components/TorrentToolbar.js
@@ -7,7 +7,6 @@ import Toolbar, {
     RemoveAndDeleteSection,
     RemoveSection,
     StartUploadingSection} from '../../../components/Toolbar'
-import TorrentTableRowStore from "../../Common/TorrentTableRowStore";
 
 const TorrentToolbar = (props) => {
   

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -3,6 +3,7 @@ import { TorrentInfo } from 'joystream-node'
 import TorrentTableRowStore from '../../Common/TorrentTableRowStore'
 import { remote } from 'electron'
 import DeepInitialState from '../../../core/Torrent/Statemachine/DeepInitialState'
+import fs from 'fs'
 
 /**
  * User interface store for downloading scene

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -117,7 +117,7 @@ class DownloadingStore {
 
   @computed get
   canAddTorrent() {
-    this.state === DownloadingStore.STATE.InitState
+    return this.state === DownloadingStore.STATE.InitState
   }
 
   startDownloadWithTorrentFileFromFilePicker () {

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -195,6 +195,12 @@ class DownloadingStore {
       this.setState(DownloadingStore.STATE.TorrentFileWasInvalid)
       return
     }
+  
+    // Check that torrent has not already been added
+    if(this._uiStore.applicationStore.torrentStores.has(torrentInfo.infoHash())) {
+      this.setState(DownloadingStore.STATE.TorrentAlreadyAdded)
+      return
+    }
 
     // Make downloading settings
     let settings = {
@@ -208,7 +214,7 @@ class DownloadingStore {
         buyerTerms: this._uiStore.applicationStore.applicationSettings.defaultBuyerTerms()
       }
     }
-
+    
     /// Try to add torrent
     this.setState(DownloadingStore.STATE.TorrentBeingAdded)
 

--- a/src/scenes/Downloading/components/TorrentRow.js
+++ b/src/scenes/Downloading/components/TorrentRow.js
@@ -67,7 +67,7 @@ const TorrentRow = observer((props) => {
 })
 
 TorrentRow.propTypes = {
-  torrentTableRowStore: PropTypes.instanceOf(TorrentTableRowStore).isRequired,
+  torrentTableRowStore: PropTypes.object.isRequired, // HMR breaks => PropTypes.instanceOf(TorrentTableRowStore).isRequired,
   backgroundColor: PropTypes.string
 }
 

--- a/src/scenes/Downloading/components/TorrentTable.js
+++ b/src/scenes/Downloading/components/TorrentTable.js
@@ -59,7 +59,7 @@ const TorrentTable = observer((props) => {
 })
 
 TorrentTable.propTypes = {
-  downloadingStore: PropTypes.instanceOf(DownloadingStore).isRequired
+  downloadingStore: PropTypes.object.isRequired // HMR breaks => PropTypes.instanceOf(DownloadingStore).isRequired
 }
 
 export default TorrentTable

--- a/src/scenes/Seeding/Components/StartUploadingFlow/IncompleteDownloadWarning.js
+++ b/src/scenes/Seeding/Components/StartUploadingFlow/IncompleteDownloadWarning.js
@@ -58,7 +58,7 @@ function getStyles (props) {
 const IncompleteDownloadWarning = (props) => {
   let styles = getStyles(props)
 
-  let savePath = props.uploadingStore.torrentWithBadSavePathDuringStartUploadFlow.savePath
+  let savePath = props.uploadingStore.torrentStoreBeingAdded.savePath
 
   return (
     <InnerDialogHeading title='Missing download'>

--- a/src/scenes/Seeding/Components/StartUploadingFlow/LoadingTorrentForUploading.js
+++ b/src/scenes/Seeding/Components/StartUploadingFlow/LoadingTorrentForUploading.js
@@ -19,7 +19,8 @@ function getStyles (props) {
     subtitle: {
       padding: '20px',
       marginTop: '30px',
-      width: '800px'
+      width: '900px',
+      textAlign: 'center'
     },
     progressBar: {
       marginTop: '50px',
@@ -45,7 +46,13 @@ const LoadingTorrentForUploading = observer((props) => {
         </div>
 
         <LinearProgress mode='determinate'
-          value={props.store.startingTorrentCheckingProgressPercentage}
+          value={
+            props.uploadingStore.torrentStoreBeingAdded
+              ?
+            props.uploadingStore.torrentStoreBeingAdded.progress
+              :
+              0
+          }
           style={styles.progressBar} />
 
       </div>
@@ -54,7 +61,7 @@ const LoadingTorrentForUploading = observer((props) => {
 })
 
 LoadingTorrentForUploading.propTypes = {
-  store: PropTypes.object.isRequired
+  uploadingStore: PropTypes.object.isRequired // is really `UploadingStore`, can't use instance
 }
 
 export default LoadingTorrentForUploading

--- a/src/scenes/Seeding/Components/TorrentRow.js
+++ b/src/scenes/Seeding/Components/TorrentRow.js
@@ -53,7 +53,7 @@ const TorrentRow = observer((props) => {
 })
 
 TorrentRow.propTypes = {
-  torrentTableRowStore: PropTypes.object.isRequired,
+  torrentTableRowStore: PropTypes.object.isRequired, // HMR breaks => PropTypes.instanceOf(TorrentTableRowStore).isRequired,
   backgroundColor: PropTypes.string
 }
 

--- a/src/scenes/Seeding/Components/TorrentTable.js
+++ b/src/scenes/Seeding/Components/TorrentTable.js
@@ -60,7 +60,7 @@ const TorrentTable = observer((props) => {
 })
 
 TorrentTable.propTypes = {
-  uploadingStore: PropTypes.object.isRequired
+  uploadingStore: PropTypes.object.isRequired // HMR breaks instanceof test on UploadingStore
 }
 
 export default TorrentTable

--- a/src/scenes/Seeding/Stores/UploadingStore.js
+++ b/src/scenes/Seeding/Stores/UploadingStore.js
@@ -209,16 +209,29 @@ class UploadingStore {
     assert(this._torrentInfoSelected)
 
     // Get settings
-    let settings = getStartingUploadSettings(this._torrentInfoSelected, savePath)
-
+  
+    let torrentInfo = this._torrentInfoSelected
+    
+    let settings = {
+      infoHash : torrentInfo.infoHash(),
+      metadata : torrentInfo,
+      resumeData : null,
+      name: torrentInfo.name(),
+      savePath: this._uiStore.applicationStore.applicationSettings.downloadFolder(),
+      deepInitialState: DeepInitialState.UPLOADING.STARTED,
+      extensionSettings : {
+        sellerTerms: this._uiStore.applicationStore.applicationSettings.defaultSellerTerms()
+      }
+    }
+    
     // Update state
     this.setState(UploadingStore.STATE.AddingTorrent)
 
     // Add torrent with given settings
     this._uiStore.applicationStore.addTorrent(settings, (err, torrentStore) => {
-
+      
       assert(this.state === UploadingStore.STATE.AddingTorrent)
-
+      
       if(err) {
 
         // NB: could there be some other issue here? if so, can we reliably decode it
@@ -317,26 +330,6 @@ class UploadingStore {
     this.setState(UploadingStore.STATE.InitState)
   }
 
-}
-
-function getStartingUploadSettings(torrentInfo, defaultSavePath) {
-
-  // NB: Get from settings data store of some sort
-  let terms = getStandardSellerTerms()
-
-  const infoHash = torrentInfo.infoHash()
-
-  return {
-    infoHash : infoHash,
-    metadata : torrentInfo,
-    resumeData : null,
-    name: torrentInfo.name() || infoHash,
-    savePath: defaultSavePath,
-    deepInitialState: TorrentStatemachine.DeepInitialState.UPLOADING.STARTED,
-    extensionSettings : {
-      sellerTerms: terms
-    }
-  }
 }
 
 export default UploadingStore

--- a/src/scenes/Seeding/Stores/UploadingStore.js
+++ b/src/scenes/Seeding/Stores/UploadingStore.js
@@ -2,6 +2,9 @@ import { observable, action, computed } from 'mobx'
 import { TorrentInfo } from 'joystream-node'
 import { remote } from 'electron'
 import TorrentTableRowStore from "../../Common/TorrentTableRowStore";
+import fs from 'fs'
+import assert from 'assert'
+import DeepInitialState from '../../../core/Torrent/Statemachine/DeepInitialState'
 
 /**
  * User interface store for uploading scene

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -454,18 +454,26 @@ class UIStore {
        */
 
       // Tell uploading store, which may need to know
-      if(this.uploadingStore)
-        this.uploadingStore.torrentFinishedDownloading(torrent.infoHash)
+      if(this.uploadingStore &&
+        this.uploadingStore.state === UploadingStore.STATE.AddingTorrent &&
+        this.uploadingStore.infoHashOfTorrentSelected === torrent.infoHash)
+        this.uploadingStore.torrentFinishedDownloading()
 
     }))
 
-    // When torrent is found to not be a complete download
-    torrent.once('Active.DownloadIncomplete', action(() => {
-
-      // Tell uploading store, which may need to know
-      if(this.uploadingStore)
-        this.uploadingStore.torrentDownloadIncomplete(torrent.infoHash)
+    // Detect when torrent is ready to start doing paid downloading, which is *always*
+    // the case when a torrent was added for uploading, but had an incomplete download from before.
+    
+    torrent.once('Active.DownloadIncomplete.Unpaid.Started.ReadyForStartPaidDownloadAttempt', action(() => {
+  
+      // Hence we must check whether this torrent is one such torrent,
+      // by checking what is currently going on on the uploading store
+      if(this.uploadingStore &&
+        this.uploadingStore.state === UploadingStore.STATE.AddingTorrent &&
+        this.uploadingStore.infoHashOfTorrentSelected === torrent.infoHash)
+        this.uploadingStore.torrentDownloadIncomplete()
     }))
+
 
     torrent.on('progress', action((progress) => {
       torrentStore.setProgress(progress * 100)


### PR DESCRIPTION
Addresses

- https://github.com/JoyStream/joystream-desktop/issues/733: fix completed scene, including https://github.com/JoyStream/joystream-desktop/issues/732
- https://github.com/JoyStream/joystream-desktop/issues/734: fix uploading scene. Now the uploading scene as correctly only shows checking progress the single torrent in question, rather than using the composite `UIStore.startingTorrentCheckingProgressPercentage`
- fixed "downloading" scene (was not fully checked).
- fixed "finished" scene: broken start uploading
- https://github.com/JoyStream/joystream-desktop/issues/708

by fixing major bugs, introducing usage of application settings for default terms and download folder. Will add tests in separate PR.