### PR TITLE
priceFeed: correctly parse exchange rate in price feed fetcher

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -1035,7 +1035,7 @@ async function exchangeRateFetcher() {
 
   let v = await coinmarketcap.tickerByAsset('bitcoin')
 
-  return v.price_usd
+  return parseFloat(v.price_usd)
 
 }
 // TODO: move this to be a method on the Torrent class and introduce a

--- a/src/core/PriceFeed/PriceFeed.js
+++ b/src/core/PriceFeed/PriceFeed.js
@@ -92,7 +92,7 @@ class PriceFeed extends EventEmitter {
     this._exchangeRateFetcher()
       .then((newExchangeRate) => {
 
-        this.cryptoToUsdExchangeRate = newExchangeRate.price_usd
+        this.cryptoToUsdExchangeRate = newExchangeRate
 
         this.emit('tick', this.cryptoToUsdExchangeRate)
       })


### PR DESCRIPTION
Simple fix for https://github.com/JoyStream/joystream-desktop/issues/754