### PR TITLE
Wallet Receive Dialog copy address to clipboard when clicked

### DIFF
--- a/src/scenes/Wallet/Components/ReceiveDialog/ReceiveDialog.js
+++ b/src/scenes/Wallet/Components/ReceiveDialog/ReceiveDialog.js
@@ -25,7 +25,8 @@ const ReceiveDialog = observer((props) => {
     let formProps = {
       address : props.receiveDialogStore.receiveAddress,
       onFlipClick : props.receiveDialogStore.flipAddressDisplayMode,
-      onClose : props.receiveDialogStore.close
+      onClose : props.receiveDialogStore.close,
+      onCopyToClipBoard: props.receiveDialogStore.copyToClipBoard
     }
 
     form =
@@ -37,7 +38,8 @@ const ReceiveDialog = observer((props) => {
   }
 
   return (
-    <Dialog title={null}
+    <Dialog title={'Receive'}
+            // TODO: Add a subtitle/warning not to send real bitcoin to this address
             open={visibleDialog}
             onRequestClose={onRequestClose}
             width={'600px'}

--- a/src/scenes/Wallet/Components/ReceiveDialog/ReceiveDialog.js
+++ b/src/scenes/Wallet/Components/ReceiveDialog/ReceiveDialog.js
@@ -26,7 +26,9 @@ const ReceiveDialog = observer((props) => {
       address : props.receiveDialogStore.receiveAddress,
       onFlipClick : props.receiveDialogStore.flipAddressDisplayMode,
       onClose : props.receiveDialogStore.close,
-      onCopyToClipBoard: props.receiveDialogStore.copyToClipBoard
+      onCopyToClipBoard: props.receiveDialogStore.copyToClipBoard,
+      displayCopiedToClipBoardAlert: props.receiveDialogStore.displayCopiedToClipBoardAlert,
+      hideCopiedToClipBoardAlert: props.receiveDialogStore.hideCopiedToClipBoardAlert
     }
 
     form =

--- a/src/scenes/Wallet/Components/ReceiveDialog/StringForm.js
+++ b/src/scenes/Wallet/Components/ReceiveDialog/StringForm.js
@@ -51,7 +51,7 @@ const StringForm = (props) => {
   return (
     <div style={styles.root}>
 
-      <div style={styles.addressContainer}>
+      <div style={styles.addressContainer} onClick={props.onCopyToClipBoard}>
 
         <span style={styles.addressField}>
           {props.address}

--- a/src/scenes/Wallet/Components/ReceiveDialog/StringForm.js
+++ b/src/scenes/Wallet/Components/ReceiveDialog/StringForm.js
@@ -6,6 +6,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 
 import Button from './Button'
+import Snackbar from 'material-ui/Snackbar'
 
 import {
   ButtonSection,
@@ -78,6 +79,10 @@ const StringForm = (props) => {
         />
 
       </ButtonSection>
+
+      { props.displayCopiedToClipBoardAlert ?
+        <Snackbar open={true} message={'Address copied to clipboard'} autoHideDuration={1000} onRequestClose={props.hideCopiedToClipBoardAlert}/> : null
+      }
 
     </div>
   )

--- a/src/scenes/Wallet/Stores/ReceiveDialogStore.js
+++ b/src/scenes/Wallet/Stores/ReceiveDialogStore.js
@@ -3,6 +3,7 @@
  */
 
 import {observable, action, runInAction, computed, autorun} from 'mobx'
+const {clipboard} = require('electron')
 
 class ReceiveDialogStore {
 
@@ -35,7 +36,7 @@ class ReceiveDialogStore {
 
   @action.bound
   copyToClipBoard() {
-    console.log('copy this to clipboard')
+    clipboard.writeText(this.receiveAddress)
   }
 
   /**

--- a/src/scenes/Wallet/Stores/ReceiveDialogStore.js
+++ b/src/scenes/Wallet/Stores/ReceiveDialogStore.js
@@ -13,6 +13,12 @@ class ReceiveDialogStore {
    */
   @observable showAddressAsQRCode
 
+ /**
+  * {Bool} Wether to show a copied to clipboard alert to user
+  * or not
+  */
+  @observable displayCopiedToClipBoardAlert
+
   /**
    * Constructor
    * @param {WalletSceneStore} walletSceneStore -
@@ -20,7 +26,7 @@ class ReceiveDialogStore {
   constructor(walletSceneStore, walletStore, showAddressAsQRCode) {
     this._walletSceneStore = walletSceneStore
     this._walletStore = walletStore
-
+    this.hideCopiedToClipBoardAlert()
     this.setShowAddressAsQRCode(showAddressAsQRCode)
   }
 
@@ -32,11 +38,25 @@ class ReceiveDialogStore {
   @action.bound
   flipAddressDisplayMode = () => {
     this.setShowAddressAsQRCode(!this.showAddressAsQRCode)
+    this.hideCopiedToClipBoardAlert()
   }
 
   @action.bound
   copyToClipBoard() {
+    console.log('copied address to clipboards')
     clipboard.writeText(this.receiveAddress)
+
+    this.showCopiedToClipBoardAlert()
+  }
+
+  @action.bound
+  showCopiedToClipBoardAlert () {
+    this.displayCopiedToClipBoardAlert = true
+  }
+
+  @action.bound
+  hideCopiedToClipBoardAlert () {
+    this.displayCopiedToClipBoardAlert = false
   }
 
   /**
@@ -50,6 +70,7 @@ class ReceiveDialogStore {
   @action.bound
   close = () => {
     this._walletSceneStore.closeCurrentDialog()
+    this.hideCopiedToClipBoardAlert()
   }
 
 }


### PR DESCRIPTION
Simply clicking on the receive address will copy it to the clipboard.
But this PR is lacking a visual cue to alert the user that copying was done.