### PR TITLE
priceFeedFetcher: drop coinmarketcap module and simply use request

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "bitcoin-convert": "^1.0.4",
     "bootstrap": "^4.0.0-alpha.6",
     "bytes": "^2.5.0",
-    "coinmarketcap": "^0.2.0",
     "currency-formatter": "^1.3.1",
     "debug": "^2.6.0",
     "electron-compile": "6.4.2",


### PR DESCRIPTION
The coinmarketcap module seemed a bit of an overkill and had some issues with newer versions of npm when used with our app.

This PR simply uses the npm request module to fetch price data from the coinmarketcap api endpoint.

It's a bit verbose but does the job.