### PR TITLE
Drop support for preferences in menu

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -61,16 +61,6 @@ const application = new Application(EXAMPLE_TORRENTS, process.env.FORCE_ONBOARDI
 
 application.on('started', () => {
 
-  // Hook into open preference command, and open file
-  // path to application settings file. In the future,
-  // this will be triggered natively from page, not from
-  // window context menu.
-  ipcRenderer.on('openPreferences', () => {
-
-    if(application.state === Application.STATE.STARTED)
-      shell.openItem(application.applicationSettings.filePath())
-  })
-
   /**
    const magnet = require('magnet-uri')
    const isDev = require('electron-is-dev')

--- a/src/menu.js
+++ b/src/menu.js
@@ -4,11 +4,6 @@ function createTemplate (win) {
     {
       label: 'Edit',
       submenu: [
-        {
-          label: 'Preferences',
-          click () { win.webContents.send('openPreferences') }
-        },
-        { type: 'separator' },
         { label: 'Copy', accelerator: 'CmdOrCtrl+C', selector: 'copy:' },
         { label: 'Paste', accelerator: 'CmdOrCtrl+V', selector: 'paste:' },
         { label: 'Select All', accelerator: 'CmdOrCtrl+A', selector: 'selectAll:' }


### PR DESCRIPTION
Hotfix to remove preferences from menu, addresses https://github.com/JoyStream/joystream-desktop/issues/781.

Causes too many issues, we should add a proper preferences dialog or scene.