### PR TITLE
bcoin: use bcoin.secp256k1 instead of bcoin.ec

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,9 @@
 // Use of pure js bcoin crypto library because electron doesn't compile with openssl
 // which is needed.
 process.env.BCOIN_NO_NATIVE = '1'
+// We can optionally turn off native secp256k1 implementation but since it doesn't
+// depend on openssl it should work fine
+// process.env.BCOIN_NO_SECP256K1 = '1'
 
 const bcoin = require('bcoin')
 

--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -749,7 +749,7 @@ class Application extends EventEmitter {
 
       //privateKeyGenerator
       () => {
-        return bcoin.ec.generatePrivateKey()
+        return bcoin.secp256k1.generatePrivateKey()
       },
 
       //publicKeyHashGenerator


### PR DESCRIPTION
Fix a breaking change in bcoin since moving from beta.12 to beta.14 based cash-spv fork