### PR TITLE
Wallet safe event handlers

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -3,6 +3,7 @@ import {EventEmitter} from "events"
 import ApplicationSettings from '../ApplicationSettings'
 import PriceFeed from '../PriceFeed'
 import Wallet from '../Wallet'
+import safeEventHandlerShim from '../Wallet/safeEventHandler'
 import Torrent from '../Torrent'
 import DeepInitialState from '../Torrent/Statemachine/DeepInitialState'
 import getCoins from './faucet'
@@ -262,13 +263,9 @@ class Application extends EventEmitter {
       this._startedResource(Application.RESOURCE.WALLET, onStarted)
     })
 
-    this.wallet.on('totalBalanceChanged', (balance) => {
-      try {
+    this.wallet.on('totalBalanceChanged', safeEventHandlerShim((balance) => {
         this._totalWalletBalanceChanged(balance)
-      } catch (err) {
-        console.error(err)
-      }
-    })
+    }),'core-wallet.totalBalanceChanged')
 
     // Start wallet
     this.wallet.start()

--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -262,7 +262,13 @@ class Application extends EventEmitter {
       this._startedResource(Application.RESOURCE.WALLET, onStarted)
     })
 
-    this.wallet.on('totalBalanceChanged', this._totalWalletBalanceChanged)
+    this.wallet.on('totalBalanceChanged', (balance) => {
+      try {
+        this._totalWalletBalanceChanged(balance)
+      } catch (err) {
+        console.error(err)
+      }
+    })
 
     // Start wallet
     this.wallet.start()
@@ -947,7 +953,7 @@ class Application extends EventEmitter {
     this.emit('onboardingIsEnabled', onboardingIsEnabled)
   }
 
-  _totalWalletBalanceChanged = (balance) => {
+  _totalWalletBalanceChanged (balance) {
 
     debug('new total balance: ' + balance)
 

--- a/src/core/Wallet/Wallet.js
+++ b/src/core/Wallet/Wallet.js
@@ -642,8 +642,8 @@ class Wallet extends EventEmitter {
       }
 
     } catch(err) {
-      console.log(err)
-      debugger
+      console.error(err)
+      return
     }
 
 
@@ -654,8 +654,8 @@ class Wallet extends EventEmitter {
        txRecord = await this._wallet.txdb.getTX(details.hash)
 
     } catch(err) {
-      console.log(err)
-      debugger
+      console.error(err)
+      return
     }
 
       // Make sure we are still started
@@ -672,8 +672,8 @@ class Wallet extends EventEmitter {
     return this._processTxRecord(txRecord, details)
 
     } catch(err) {
-      console.log(err)
-      debugger
+      console.error(err)
+      return
     }
   }
 
@@ -746,8 +746,8 @@ class Wallet extends EventEmitter {
       }
 
     } catch(err) {
-      console.log(err)
-      debugger
+      console.error(err)
+      return
     }
 
 

--- a/src/core/Wallet/Wallet.js
+++ b/src/core/Wallet/Wallet.js
@@ -176,14 +176,16 @@ class Wallet extends EventEmitter {
     overrideBcoinPoolHandleTxInv(this._spvNode.pool)
 
     this._spvNode.chain.on('block', (block, entry) => {
+      try {
+        // Update height of chain
+        this._setBlockTipHeight(this._spvNode.chain.height)
 
-      // Update height of chain
-      this._setBlockTipHeight(this._spvNode.chain.height)
-
-      // Update synch
-      let synchronizedBlockHeight = this.synchronizedBlockHeight * this._spvNode.chain.getProgress()
-      this._setSynchronizedBlockHeight(synchronizedBlockHeight)
-
+        // Update synch
+        let synchronizedBlockHeight = this.synchronizedBlockHeight * this._spvNode.chain.getProgress()
+        this._setSynchronizedBlockHeight(synchronizedBlockHeight)
+      } catch (err) {
+        console.error(err)
+      }
       // _spvNode.pool.x?  what do peers report as the current tip of their longest chain?
       // it is sent in the version message when we connect to them
     })
@@ -259,28 +261,48 @@ class Wallet extends EventEmitter {
       console.log(tx)
       console.log(details)
 
-      this._newTransaction(tx, details)
+      try {
+        this._newTransaction(tx, details)
+      } catch (err) {
+        console.error(err)
+      }
     })
 
     this._wallet.on('confirmed', (tx, details) => {
-      this._transactionConfirmed(tx, details)
+      try {
+        this._transactionConfirmed(tx, details)
+      } catch (err) {
+        console.error(err)
+      }
+
     })
 
     this._wallet.on('unconfirmed', (tx, details) => {
-      this._transactionUnconfirmed(tx, details)
+      try {
+        this._transactionUnconfirmed(tx, details)
+      } catch (err) {
+        console.error(err)
+      }
     })
 
     this._wallet.on('balance', (balance) => {
-      this._setConfirmedBalance(balance.confirmed)
-      this._setTotalBalance(balance.unconfirmed)
+      try {
+        this._setConfirmedBalance(balance.confirmed)
+        this._setTotalBalance(balance.unconfirmed)
+      } catch (err) {
+        console.error(err)
+      }
     })
 
     // New receive address generated
     this._wallet.on('address', (derived) => {
+      try {
+        let receiveAddress = derived[0].getAddress()
 
-      let receiveAddress = derived[0].getAddress()
-
-      this.emit('receiveAddressChanged', receiveAddress)
+        this.emit('receiveAddressChanged', receiveAddress)
+      } catch (err) {
+        console.error(err)
+      }
     })
 
     /// Get balance
@@ -381,24 +403,8 @@ class Wallet extends EventEmitter {
     }
   }
 
-  _spvNodeError(err) {
-
-    console.log('spvNodeError: ' + err)
-
-    if (err.code !== 'EADDRINUSE')
-      return
-    else
-      console.log('seems serious')
-
-    /**
-     if (error.handled)
-     return
-
-     code marked "temp" is workaround until http listen fix is merged into bcoin release
-
-     error.handled = true
-     this.node = null // to skip call to spvnode.close() in closeSpvNode() - because asyncobject might still be locked
-     */
+  _spvNodeError (err) {
+    console.error('spvNodeError:', err)
   }
 
   /**

--- a/src/core/Wallet/safeEventHandler.js
+++ b/src/core/Wallet/safeEventHandler.js
@@ -1,0 +1,17 @@
+const debugSafeEventHandler = require('debug')('safe-event-handler')
+
+// Safe event handler which should be used to wrap event handlers for bcoin wallet
+// and node events, to prevent unhandled exceptions from breaking bcoin behaviour
+function safeEventHandlerShim (handler, eventName) {
+
+  return function safeBcoinHandler (...args) {
+    try {
+      handler(...args)
+    } catch (err) {
+      debugSafeEventHandler('Unhandled exception caught in handler for event ' + eventName)
+      debugSafeEventHandler(err)
+    }
+  }
+}
+
+module.exports = safeEventHandlerShim


### PR DESCRIPTION
Ensure all bcoin wallet event handlers do not throw exceptions. some events emitted by the bcoin txdb while committing TXs or blocks to the database may get interrupted with various outcomes. 

Removed `debugger` statements