### PR TITLE
fix duplicate payment store being created when sending payments

### DIFF
--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -324,7 +324,7 @@ class UIStore {
       }))
 
     } else if(resource === Application.RESOURCE.WALLET) {
-      
+
       /**
        * Create and setup wallet store
        */
@@ -345,7 +345,7 @@ class UIStore {
         [],
         wallet.pay.bind(wallet)
       )
-  
+
       this.applicationStore.setWalletStore(walletStore)
 
       // Hook into events
@@ -384,7 +384,7 @@ class UIStore {
         '',
         launchExternalTxViewer
       )
-      
+
     }
 
   })
@@ -445,27 +445,27 @@ class UIStore {
     /// Hook into events
 
     torrent.on('state', action((state) => {
-      
+
       torrentStore.setState(state)
-  
+
       /**
        * When torrent is finished, we have to count towards the navigator
        * Bug: see here https://github.com/JoyStream/joystream-desktop/issues/764
        */
-  
+
       if(state === 'Active.FinishedDownloading.Passive') {
-    
+
         assert(this.applicationNavigationStore)
         this.applicationNavigationStore.handleTorrentCompleted()
-        
+
         // In the future: Add desktop notifications!
-        
+
       }
-      
+
     }))
-    
+
     torrent.on('loaded', action((deepInitialState) => {
-  
+
       /**
        * When adding a torrent through the uploading flow,
        * we need to learn whether uploading the given torrent is feasible,
@@ -476,17 +476,17 @@ class UIStore {
        * if there is such an uploading flow going for the given torrent,
        * and notify the given scene model about the download status.
        */
-      
+
       if(this.uploadingStore &&
         this.uploadingStore.state === UploadingStore.STATE.AddingTorrent &&
         this.uploadingStore.infoHashOfTorrentSelected === torrent.infoHash) {
-        
+
         if(torrent.state.startsWith('Active.DownloadIncomplete'))
           this.uploadingStore.torrentDownloadIncomplete()
         else if(torrent.state.startsWith('Active.FinishedDownloading'))
           this.uploadingStore.torrentFinishedDownloading()
       }
-      
+
     }))
 
     torrent.on('viabilityOfPaidDownloadInSwarm', action((viabilityOfPaidDownloadInSwarm) => {
@@ -515,7 +515,7 @@ class UIStore {
       torrentStore.setTotalSize(torrentInfo.totalSize())
       torrentStore.setTorrentFiles(torrentInfo.files())
     }))
-    
+
     torrent.on('progress', action((progress) => {
       torrentStore.setProgress(progress * 100)
     }))
@@ -733,7 +733,7 @@ class UIStore {
     let walletStore = this.applicationStore.walletStore
     assert(walletStore)
 
-    walletStore.paymentStores.push(paymentStore)
+    walletStore.addPaymentStore(paymentStore)
 
     /// Hook up events
 
@@ -787,7 +787,7 @@ class UIStore {
     // Initiate closing application
     this.closeApplication()
   }
-  
+
   /**
    * Closes the application, but firrst enables possible
    * onboarding flow if its currently enabled.
@@ -826,7 +826,7 @@ class UIStore {
     }
 
   }
-  
+
   /**
    * Directly initiates application stoppage.
    */

--- a/test/core-stores/Wallet/Wallet.js
+++ b/test/core-stores/Wallet/Wallet.js
@@ -1,6 +1,8 @@
 import 'babel-polyfill' //async-await
 
 import WalletStore from '../../../src/core-stores/Wallet/WalletStore'
+import PaymentStore from '../../../src/core-stores/Wallet/PaymentStore'
+
 import {assert} from 'chai'
 var PromiseMock = require('promise-mock')
 
@@ -75,16 +77,19 @@ describe('Wallet Store', function () {
 
       assert(!pay.called)
 
-      let paymentPromise = walletStore.pay('hash', 1, 10, 'note')
+      let paymentStorePromise = walletStore.pay('hash', 1, 10, 'note')
 
       assert(pay.called)
 
       pay.returnValues[0].resolve(payment)
 
+      // a payment store is created
+      walletStore.addPaymentStore(new PaymentStore(payment))
+
       Promise.runAll()
 
       // pay method returns a new payment store from the payment
-      assert.deepEqual(PromiseMock.getResult(paymentPromise), payment)
+      assert.deepEqual(PromiseMock.getResult(paymentStorePromise), payment)
 
       // ... and adds the new payment store to the array of paymentStores
       assert.equal(walletStore.paymentStores.length, numPaymentStores + 1)


### PR DESCRIPTION
Fixes Rendering of payments table which had duplicate keys, because a sent payment was getting added twice to the paymentStores array in the WalletStore