### PR TITLE
Wallet: correctly compute the total and pending balances

### DIFF
--- a/src/core/Wallet/Wallet.js
+++ b/src/core/Wallet/Wallet.js
@@ -272,7 +272,7 @@ class Wallet extends EventEmitter {
 
     this._wallet.on('balance', (balance) => {
       this._setConfirmedBalance(balance.confirmed)
-      this._setTotalBalance(balance.confirmed + balance.unconfirmed)
+      this._setTotalBalance(balance.unconfirmed)
     })
 
     // New receive address generated
@@ -307,7 +307,7 @@ class Wallet extends EventEmitter {
     }
 
     this._setConfirmedBalance(balance.confirmed)
-    this._setTotalBalance(balance.confirmed + balance.unconfirmed)
+    this._setTotalBalance(balance.unconfirmed)
 
     /// Connect to peer network
 

--- a/src/scenes/Wallet/Stores/WalletSceneStore.js
+++ b/src/scenes/Wallet/Stores/WalletSceneStore.js
@@ -114,7 +114,13 @@ class WalletSceneStore {
 
   @computed get
   pendingBalance() {
-    return this._walletStore.totalBalance - this._walletStore.confirmedBalance
+    let pendingBalance = this._walletStore.totalBalance - this._walletStore.confirmedBalance
+
+    if (pendingBalance < 0) {
+      debugger
+    }
+
+    return pendingBalance
   }
 
   @computed get


### PR DESCRIPTION
Fixes #775 
See https://github.com/bcoin-org/bcoin/issues/163#issuecomment-286235012 for explanation on how to interpret the balance.confirmed and balance.unconfirmed values.