### PR TITLE
disabled "pending" balance on wallet scene

### DIFF
--- a/src/scenes/Wallet/Components/LiveWalletSceneContent.js
+++ b/src/scenes/Wallet/Components/LiveWalletSceneContent.js
@@ -176,10 +176,10 @@ const LiveWalletSceneContent = inject('uiConstantsStore')(inject('UIStore')(obse
                                {...labelColorProps}
             />
             
-            <CurrencyLabel labelText={"PENDING"}
+            {/*<CurrencyLabel labelText={"PENDING"}
                            satoshies={props.UIStore.walletSceneStore.pendingBalance}
                            {...labelColorProps}
-            />
+            />*/}
           
           </LabelContainer>
         


### PR DESCRIPTION
sometimes it gets computed to a negative value making getCompactBitcoinUnits throw!
Disabling for now

