### PR TITLE
disable wallet sync progress label

### DIFF
--- a/src/scenes/Wallet/Components/LiveWalletSceneContent.js
+++ b/src/scenes/Wallet/Components/LiveWalletSceneContent.js
@@ -171,10 +171,10 @@ const LiveWalletSceneContent = inject('uiConstantsStore')(inject('UIStore')(obse
           <MaxFlexSpacer />
           
           <LabelContainer>
-            
+            {/* Disabled - high CPU utilization when animating circural progress
             <WalletStatusLabel synchronizationPercentage={props.UIStore.walletSceneStore.synchronizationPercentage}
                                {...labelColorProps}
-            />
+            />*/}
             
             {/*<CurrencyLabel labelText={"PENDING"}
                            satoshies={props.UIStore.walletSceneStore.pendingBalance}


### PR DESCRIPTION
Disabling the wallet sync progress indicator (spinner) to avoid high CPU and confusion about it is communicating to the user.