### PR TITLE
Lower fees

### DIFF
--- a/src/core/Application/Application.js
+++ b/src/core/Application/Application.js
@@ -57,17 +57,17 @@ const DEFAULT_APPLICATION_SETTINGS = {
 
   buyerTerms : {
     maxPrice: 20,
-    maxLock: 5,
+    maxLock: 20,
     minNumberOfSellers: 1,
-    maxContractFeePerKb: 2000
+    maxContractFeePerKb: 1024
   },
 
   sellerTerms : {
     minPrice: 20,
-    minLock: 1,
+    minLock: 10,
     maxNumberOfSellers: 5,
-    minContractFeePerKb: 2000,
-    settlementFee: 2000
+    minContractFeePerKb: 1024,
+    settlementFee: 450
   },
 
   termsAccepted : false,

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -375,8 +375,7 @@ class UIStore {
       // let satsPrkBFee = 0.00239 * bcoin.protocol.consensus.COIN
 
       // http://statocashi.info/dashboard/db/fee-estimates?orgId=1&from=now-7d&to=now
-      // We can get away with very low 2 Sat/byte
-      let satsPrkBFee = 2048
+      let satsPrkBFee = 1050
 
       // We need settings to be opened, and we are guaranteed that this has happened
       // before wallet is ready


### PR DESCRIPTION
Revised standard terms:

Increased the minLock time (1 was too low, making it such that the settlement tx will have to compete with buyer's full refund tx)

Lowered fees to target 1sat/Byte (in contract, settlement, and regular payments)