### PR TITLE
fix: disabled all the async state handling in toolbars

### DIFF
--- a/src/component-development/MockApplicationAnimator.js
+++ b/src/component-development/MockApplicationAnimator.js
@@ -1,5 +1,6 @@
 import Application from '../core/Application'
 import Wallet, {Payment} from '../core/Wallet'
+import ApplicationSettings from '../core/ApplicationSettings'
 import {
   MockApplication,
   MockWallet,
@@ -44,6 +45,8 @@ class MockApplicationAnimator {
 
     this.mockApplication.applicationSettings = mockApplicationSettings
     this.mockApplication.emit('resourceStarted', Application.RESOURCE.SETTINGS)
+
+    mockApplicationSettings.state = ApplicationSettings.STATE.OPENED
   }
   
   setWallet() {

--- a/src/components/Toolbar/RemoveAndDeleteSection.js
+++ b/src/components/Toolbar/RemoveAndDeleteSection.js
@@ -23,7 +23,6 @@ const RemoveAndDeleteSection = observer((props) => {
       if (props.working) {
         // show spinner
         className = 'trash_working'
-        tooltip = 'Removing...'
       } else {
         // show disabled
         className = 'trash_disabled'

--- a/src/components/Toolbar/RemoveSection.js
+++ b/src/components/Toolbar/RemoveSection.js
@@ -23,7 +23,6 @@ const RemoveSection = observer((props) => {
       if (props.working) {
         // show spinner
         className = 'remove_working'
-        tooltip = 'Removing...'
       } else {
         // show disabled
         className = 'remove_disabled'

--- a/src/scenes/Completed/components/TorrentToolbar.js
+++ b/src/scenes/Completed/components/TorrentToolbar.js
@@ -22,12 +22,12 @@ const TorrentToolbar = observer((props) => {
                              onClick={() => { props.torrentTableRowStore.beginPaidUploadWithDefaultTerms() }}
       />
 
-      <RemoveSection enabled={!props.torrentTableRowStore.beingRemoved}
-                     working={props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData}
+      <RemoveSection enabled={true /** !props.torrentTableRowStore.beingRemoved **/}
+                     working={false /** props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData **/}
                      onClick={() => { props.torrentTableRowStore.remove() }} />
 
-      <RemoveAndDeleteSection enabled={!props.torrentTableRowStore.beingRemoved}
-                              working={props.torrentTableRowStore.deletingData}
+      <RemoveAndDeleteSection enabled={true /** !props.torrentTableRowStore.beingRemoved **/}
+                              working={false /** props.torrentTableRowStore.deletingData **/}
                               onClick={() => { props.torrentTableRowStore.removeAndDeleteData() }} />
 
       <OpenFolderSection onClick={() => { props.torrentTableRowStore.openFolder() }} />

--- a/src/scenes/Downloading/components/TorrentToolbar.js
+++ b/src/scenes/Downloading/components/TorrentToolbar.js
@@ -37,12 +37,12 @@ const TorrentToolbar = observer((props) => {
 
       {/** <ChangeBuyerTermsSection torrent={props.torrent}/> **/}
 
-      <RemoveSection enabled={!props.torrentTableRowStore.beingRemoved}
-                     working={props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData}
+      <RemoveSection enabled={true /** !props.torrentTableRowStore.beingRemoved **/}
+                     working={false /** props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData **/}
                      onClick={() => { props.torrentTableRowStore.remove() }} />
 
-      <RemoveAndDeleteSection enabled={!props.torrentTableRowStore.beingRemoved}
-                              working={props.torrentTableRowStore.deletingData}
+      <RemoveAndDeleteSection enabled={true /** !props.torrentTableRowStore.beingRemoved **/}
+                              working={false /** props.torrentTableRowStore.deletingData **/}
                               onClick={() => { props.torrentTableRowStore.removeAndDeleteData() }} />
 
       <OpenFolderSection onClick={() => { props.torrentTableRowStore.openFolder() }} />

--- a/src/scenes/Seeding/Components/TorrentToolbar.js
+++ b/src/scenes/Seeding/Components/TorrentToolbar.js
@@ -23,12 +23,12 @@ const TorrentToolbar = observer((props) => {
 
       <StopUploadingSection onClick={() => { props.torrentTableRowStore.torrentStore.endUploading() }} />
 
-      <RemoveSection enabled={!props.torrentTableRowStore.beingRemoved}
-                     working={props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData}
+      <RemoveSection enabled={true /**!props.torrentTableRowStore.beingRemoved **/}
+                     working={false /**props.torrentTableRowStore.beingRemoved && !props.torrentTableRowStore.deletingData **/}
                      onClick={() => { props.torrentTableRowStore.remove() }} />
 
-      <RemoveAndDeleteSection enabled={!props.torrentTableRowStore.beingRemoved}
-                              working={props.torrentTableRowStore.deletingData}
+      <RemoveAndDeleteSection enabled={true /**!props.torrentTableRowStore.beingRemoved **/}
+                              working={false /** props.torrentTableRowStore.deletingData **/}
                               onClick={() => { props.torrentTableRowStore.removeAndDeleteData() }} />
 
       <OpenFolderSection onClick={() => { props.torrentTableRowStore.openFolder() }} />

--- a/test/core/Mocks/index.js
+++ b/test/core/Mocks/index.js
@@ -10,6 +10,7 @@ import MockApplication from './Application'
 import MockWallet from './Wallet'
 import MockJSNodeTorrent from './MockJSNodeTorrent'
 import MockApplicationSettings from './ApplicationSettings'
+import MockPriceFeed from './PriceFeed'
 
 // export all mocks
 export {
@@ -24,5 +25,6 @@ export {
   MockApplication,
   MockWallet,
   MockJSNodeTorrent,
-  MockApplicationSettings
+  MockApplicationSettings,
+  MockPriceFeed
 }


### PR DESCRIPTION
Dropping the partial attempt at async processing in toolbar actions, created a standalone issue for it here https://github.com/JoyStream/joystream-desktop/issues/866.