### PR TITLE
call play on video element when video player component mounts

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.js
+++ b/src/components/VideoPlayer/VideoPlayer.js
@@ -21,7 +21,11 @@ class VideoPlayer extends Component {
   }
 
   componentDidMount () {
-
+    // Despite autoPlay attribute being set on the video element, if no data is yet available
+    // from the stream, the video player just stalls and gets paused. It will not try to fetch additional
+    // data from the stream unless we invoke play() again on the element
+    // Also we want to always force playing so the torrent progress dialog will appear
+    getVideoDOMElement().play()
   }
 
   handleMouseEnter () {


### PR DESCRIPTION
When media player is launched and attempting to play a video from a torrent stream that has no content yet, the video is paused. Even when data arrives on the stream the video doesn't automatically resume playing and user has to manually click the play control button.

Solution is to call play on the video element when the react component mounts.