### PR TITLE
open external links with "opn" works across all platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "mobx-react": "^4.1.3",
     "mobx-react-devtools": "^4.2.15",
     "node-notifier": "^5.2.1",
-    "open": "0.0.5",
+    "opn": "^5.3.0",
     "popper.js": "^1.12.5",
     "prop-types": "^15.5.8",
     "qrcode-react": "^0.1.12",

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ import os from 'os'
 import path from 'path'
 import isDev from 'electron-is-dev'
 import React from 'react'
+import opn from 'opn'
 
 import Application from './core/Application'
 
@@ -56,7 +57,8 @@ var injectTapEventPlugin = require('react-tap-event-plugin')
 injectTapEventPlugin()
 
 const getCoins = (address) => {
-  shell.openExternal('http://download.joystream.co:7200/?address=' + address.toString())
+  const url = 'http://download.joystream.co:7200/?address=' + address.toString()
+  opn(url).catch(() => {})
 }
 
 // Create app

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,3 +1,4 @@
+import opn from 'opn'
 
 function createTemplate (win) {
   const template = [
@@ -27,7 +28,7 @@ function createTemplate (win) {
       submenu: [
         {
           label: 'Learn More',
-          click () { require('electron').shell.openExternal('http://joystream.co/') }
+          click () { opn('http://joystream.co/').catch(() => {}) }
         }
       ]
     }

--- a/src/scenes/Community/Community.js
+++ b/src/scenes/Community/Community.js
@@ -5,7 +5,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { inject } from 'mobx-react'
-import open from 'open'
+import opn from 'opn'
 
 import {TELEGRAM_URL, SLACK_URL, REDDIT_URL} from '../../constants'
 
@@ -63,7 +63,7 @@ const Community = inject('UIStore')((props) => {
 
         <IconButton iconStyle={styles.svgIcon}
           style={styles.iconButton}
-          onClick={() => { open(TELEGRAM_URL) }}>
+          onClick={() => { opn(TELEGRAM_URL).catch(() => {}) }}>
           <TelegramIcon />
         </IconButton>
 
@@ -71,7 +71,7 @@ const Community = inject('UIStore')((props) => {
 
         <IconButton iconStyle={styles.svgIcon}
           style={styles.iconButton}
-          onClick={() => { open(SLACK_URL) }}>
+          onClick={() => { opn(SLACK_URL).catch(() => {}) }}>
           <SlackIcon />
         </IconButton>
 
@@ -79,7 +79,7 @@ const Community = inject('UIStore')((props) => {
 
         <IconButton iconStyle={styles.svgIcon}
           style={styles.iconButton}
-          onClick={() => { open(REDDIT_URL) }}>
+          onClick={() => { opn(REDDIT_URL).catch(() => {}) }}>
           <RedditIcon />
         </IconButton>
 

--- a/src/scenes/UIStore.js
+++ b/src/scenes/UIStore.js
@@ -1,7 +1,7 @@
 import {observable, action, computed} from 'mobx'
 import assert from 'assert'
 import {shell, remote} from 'electron'
-import open from 'open'
+import opn from 'opn'
 var debug = require('debug')('UIStore')
 
 // Core
@@ -1190,7 +1190,7 @@ function launchExternalTxViewer(txId, outputIndex) {
 
   console.log('Opening payment carried by output ' + outputIndex + ' in tx ' + txId)
 
-  shell.openExternal(constants.BLOCKEXPLORER_QUERY_STRING_BASE + txId)
+  opn(constants.BLOCKEXPLORER_QUERY_STRING_BASE + txId).catch(() => {})
 }
 
 function appStateToUIStorePhase(state) {

--- a/src/scenes/Wallet/Components/LoadingWalletSceneContent.js
+++ b/src/scenes/Wallet/Components/LoadingWalletSceneContent.js
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types'
 import { inject, observer } from 'mobx-react'
 
 import Wallet from '../../../core/Wallet'
-import {REDDIT_URL, SLACK_URL, TELEGRAM_URL} from "../../../constants";
-import open from "open";
 
 function getStyles (props) {
   return {


### PR DESCRIPTION
Fixes https://github.com/JoyStream/joystream-desktop/issues/524
and opening external browser to view transactions in a block explorer.