### PR TITLE
Improve UX of StartPaidDownloadingField

### DIFF
--- a/src/component-development/IsolatedComponents.js
+++ b/src/component-development/IsolatedComponents.js
@@ -76,14 +76,32 @@ class StartPaidDownloadingFieldSection extends Component {
     return row
   }
 
+  static makeOptimisingRowStore() {
+
+    let infoHash = 'info3'
+    let torrentStore = {
+      infoHash: infoHash
+    }
+    let uiStore = {
+      torrentsViabilityOfPaidDownloading : {
+        get : function() {
+          return new CanStart({ }, 123)
+        }
+      }
+    }
+    let row = new TorrentTableRowStore(torrentStore, uiStore, false)
+    row.setBlockedStartingPaidDownloadForSwarmLatencySampling(true)
+
+    return row
+  }
+
   constructor() {
     super()
 
-
-
     this.state = {
       startPaidDownloadTorrentTableRowStore : StartPaidDownloadingFieldSection.makeStartingPaidDownloadRowStore(),
-      outOfMoneyStartPaidDownloadTorrentTableRowStore : StartPaidDownloadingFieldSection.makeOutOfMoneyRowStore()
+      outOfMoneyStartPaidDownloadTorrentTableRowStore : StartPaidDownloadingFieldSection.makeOutOfMoneyRowStore(),
+      optimisingRowStore : StartPaidDownloadingFieldSection.makeOptimisingRowStore()
     }
   }
 
@@ -111,6 +129,10 @@ class StartPaidDownloadingFieldSection extends Component {
 
         <div style={styles.wrapper}>
           <StartPaidDownloadingField torrentTableRowStore={this.state.outOfMoneyStartPaidDownloadTorrentTableRowStore}/>
+        </div>
+
+        <div style={styles.wrapper}>
+          <StartPaidDownloadingField torrentTableRowStore={this.state.optimisingRowStore}/>
         </div>
 
       </div>

--- a/src/component-development/IsolatedComponents.js
+++ b/src/component-development/IsolatedComponents.js
@@ -34,17 +34,15 @@ const IsolatedComponents = (props) => {
 
 import StartPaidDownloadingField from '../scenes/Downloading/components/StartPaidDownloadingField'
 import TorrentTableRowStore from '../scenes/Common/TorrentTableRowStore'
-import {CanStart} from '../scenes/Common/ViabilityOfPaidDownloadingTorrent'
+import {CanStart, InsufficientFunds} from '../scenes/Common/ViabilityOfPaidDownloadingTorrent'
 
 class StartPaidDownloadingFieldSection extends Component {
 
-  constructor() {
-    super()
+  static makeStartingPaidDownloadRowStore() {
 
-    // Torrent 1
-    let infoHash_1 = 'info1'
+    let infoHash = 'info1'
     let torrentStore = {
-      infoHash: infoHash_1
+      infoHash: infoHash
     }
     let uiStore = {
       torrentsViabilityOfPaidDownloading : {
@@ -56,15 +54,66 @@ class StartPaidDownloadingFieldSection extends Component {
     let row = new TorrentTableRowStore(torrentStore, uiStore, false)
     row.setStartingPaidDownload(true)
 
+    return row
+  }
+
+  static makeOutOfMoneyRowStore() {
+
+    let infoHash = 'info2'
+    let torrentStore = {
+      infoHash: infoHash
+    }
+    let uiStore = {
+      torrentsViabilityOfPaidDownloading : {
+        get : function() {
+          return new InsufficientFunds(99999, 222)
+        }
+      }
+    }
+    let row = new TorrentTableRowStore(torrentStore, uiStore, false)
+    row.setStartingPaidDownload(true)
+
+    return row
+  }
+
+  constructor() {
+    super()
+
+
+
     this.state = {
-      startPaidDownloadTorrentTableRowStore : row
+      startPaidDownloadTorrentTableRowStore : StartPaidDownloadingFieldSection.makeStartingPaidDownloadRowStore(),
+      outOfMoneyStartPaidDownloadTorrentTableRowStore : StartPaidDownloadingFieldSection.makeOutOfMoneyRowStore()
     }
   }
 
   render() {
 
+    let styles = {
+      root : {
+        display: 'flex',
+        flexDirection: 'column',
+        width: '300px',
+      },
+      wrapper: {
+        display: 'flex',
+        flexDirection: 'row',
+        marginBottom: '20px'
+      }
+    }
+
     return (
-      <StartPaidDownloadingField torrentTableRowStore={this.state.startPaidDownloadTorrentTableRowStore}/>
+      <div style={styles.root}>
+
+        <div style={styles.wrapper}>
+          <StartPaidDownloadingField torrentTableRowStore={this.state.startPaidDownloadTorrentTableRowStore}/>
+        </div>
+
+        <div style={styles.wrapper}>
+          <StartPaidDownloadingField torrentTableRowStore={this.state.outOfMoneyStartPaidDownloadTorrentTableRowStore}/>
+        </div>
+
+      </div>
     )
   }
 }

--- a/src/scenes/Common/TorrentTableRowStore.js
+++ b/src/scenes/Common/TorrentTableRowStore.js
@@ -33,6 +33,11 @@ class TorrentTableRowStore {
    */
   @observable startingPaidDownload
 
+  /**
+   * {Boolean}
+   */
+  @observable blockedStartingPaidDownloadForSwarmLatencySampling
+
   constructor(torrentStore, uiStore, showToolbar) {
 
     this.torrentStore = torrentStore
@@ -72,6 +77,11 @@ class TorrentTableRowStore {
   @action.bound
   setStartingPaidDownload(startingPaidDownload) {
     this.startingPaidDownload = startingPaidDownload
+  }
+
+  @action.bound
+  setBlockedStartingPaidDownloadForSwarmLatencySampling(blockedStartingPaidDownloadForSwarmLatencySampling) {
+    this.blockedStartingPaidDownloadForSwarmLatencySampling = blockedStartingPaidDownloadForSwarmLatencySampling
   }
 
   remove () {

--- a/src/scenes/Downloading/Stores/DownloadingStore.js
+++ b/src/scenes/Downloading/Stores/DownloadingStore.js
@@ -59,6 +59,17 @@ class DownloadingStore {
 
     let row = new TorrentTableRowStore(torrentStore, this._uiStore, false)
 
+    // Block any paid download initiation
+    row.setBlockedStartingPaidDownloadForSwarmLatencySampling(true)
+
+    // Enable it again after some time
+    setTimeout(
+      () => {
+      row.setBlockedStartingPaidDownloadForSwarmLatencySampling(false)
+    },
+      10000 // Moved into application settings later
+    )
+
     this.rowStorefromTorrentInfoHash.set(torrentStore.infoHash, row)
   }
 

--- a/src/scenes/Downloading/components/StartPaidDownloadingField.js
+++ b/src/scenes/Downloading/components/StartPaidDownloadingField.js
@@ -43,6 +43,15 @@ function getColors(props, state) {
 
     }
 
+  } else if (props.torrentTableRowStore.viabilityOfPaidDownloadingTorrent.constructor.name === 'InsufficientFunds') {
+
+    return {
+      textColor: 'white',
+      subTextColor: 'rgba(255,255,255, 0.7)',
+      borderColor : 'transparent',
+      background : '#ff9800'
+    }
+
   } else if (props.torrentTableRowStore.viabilityOfPaidDownloadingTorrent.constructor.name === 'AlreadyStarted') {
     return {
       textColor: 'black',
@@ -151,7 +160,8 @@ function getText(torrentTableRowStore) {
       tooltip = "The wallet is still getting ready, please stand by, this should complete shortly."
     }
     else if(viabilityOfPaidDownloadingTorrent.constructor.name === 'InsufficientFunds') {
-      subText = "Insufficient funds"
+      text = "BOOST AVAILABLE"
+      subText = "Needs funds"
       tooltip = "The estimated minimum value of X is required to start a paid download, you only have Y currently available."
     }
     else if(viabilityOfPaidDownloadingTorrent.constructor.name === 'Stopped') {
@@ -327,7 +337,7 @@ const StartPaidDownloadingField = (props) => {
 
   let styles = {
     root : {
-      flex: '0 0 180px'
+      flex: '0 0 220px'
     }
   }
 

--- a/src/scenes/Downloading/components/StartPaidDownloadingField.js
+++ b/src/scenes/Downloading/components/StartPaidDownloadingField.js
@@ -23,6 +23,15 @@ function getColors(props, state) {
         background : 'hsla(180, 1%, 80%, 0.4)'
       }
 
+    } else if (props.torrentTableRowStore.blockedStartingPaidDownloadForSwarmLatencySampling) {
+
+      return {
+        textColor: 'rgba(139, 152, 27, 1)',
+        subTextColor: 'rgba(139, 152, 27, 0.7)',
+        borderColor : 'transparent',
+        background : '#cddc39'
+      }
+
     } else {
 
       if (state.hover) {
@@ -145,6 +154,9 @@ function getText(torrentTableRowStore) {
 
     if(torrentTableRowStore.startingPaidDownload) {
       text = "STARTING BOOST"
+    } else if(torrentTableRowStore.blockedStartingPaidDownloadForSwarmLatencySampling) {
+      text = "OPTIMISING SPEED"
+      subText = "Finding best peers"
     } else {
       text = "BOOST"
       subText="Pay for speedup"
@@ -248,11 +260,12 @@ class StartPaidDownloadButton extends Component {
       this.props.torrentTableRowStore.handlePaidDownloadClick()
   }
 
-  blockingWhileProcessingStartPaidDownload() {
-    return
-    this.props.torrentTableRowStore.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart'
-      &&
-      this.props.torrentTableRowStore.startingPaidDownload
+  blocking() {
+    return this.props.torrentTableRowStore.viabilityOfPaidDownloadingTorrent.constructor.name === 'CanStart'
+      && (
+      this.props.torrentTableRowStore.startingPaidDownload ||
+      this.props.torrentTableRowStore.blockedStartingPaidDownloadForSwarmLatencySampling
+    )
   }
 
   render() {
@@ -274,14 +287,12 @@ class StartPaidDownloadButton extends Component {
 
         >
           {
-            this.blockingWhileProcessingStartPaidDownload()
+            this.blocking()
             ?
               <CircularProgress size={20} thickness={2} color={styles.colors.textColor}/>
             :
               <InformationSvgIcon style={styles.speedupSvgIcon} data-tip data-for={iconIdentifier} />
           }
-
-
         </div>
 
         <div style={styles.textContainer}>


### PR DESCRIPTION
Addresses

- https://github.com/JoyStream/joystream-desktop/issues/982
- https://github.com/JoyStream/joystream-desktop/issues/990

## Salient UI warning of being out of funds

![screen shot 2018-04-17 at 20 45 19](https://user-images.githubusercontent.com/437292/38910840-4b388928-4280-11e8-9b71-a18e08898607.png)

## Block instant downloading

![screen shot 2018-04-18 at 02 24 34](https://user-images.githubusercontent.com/437292/38923564-ba48eacc-42af-11e8-8118-10c617c78e7b.png)

